### PR TITLE
Handle more than 1 build

### DIFF
--- a/Sources/BSBuildService/main.swift
+++ b/Sources/BSBuildService/main.swift
@@ -19,13 +19,12 @@ enum BasicResponseHandler {
         let url = URL(fileURLWithPath: "/tmp/xcbuild.log")
         let entry = str + "\n"
         do {
-           let fileUpdater = try FileHandle(forWritingTo: url) 
-           fileUpdater.seekToEndOfFile()
-           fileUpdater.write(entry.data(using: .utf8)!)
-           fileUpdater.closeFile()
+            let fileUpdater = try FileHandle(forWritingTo: url) 
+            fileUpdater.seekToEndOfFile()
+            fileUpdater.write(entry.data(using: .utf8)!)
+            fileUpdater.closeFile()
         } catch {
             try! entry.write(to: url, atomically: false, encoding: .utf8)
-            // fatalError(error.localizedDescription)
         }
     }
 
@@ -102,7 +101,6 @@ enum BasicResponseHandler {
         XCBRawValue.uint(0),
         XCBRawValue.string("PING"),
         XCBRawValue.nil,
-        //XCBRawValue.uint(6),
         XCBRawValue.uint(gMsgId + 1),
 
         ]

--- a/Sources/BSBuildService/main.swift
+++ b/Sources/BSBuildService/main.swift
@@ -251,18 +251,6 @@ enum BasicResponseHandler {
         XCBRawValue.uint(gMsgId - 3),
         ]
     }
-    
-    // This currently fails ( couldn't decode a bool )
-    static func planningOperationWillStartResponse3n(_ input: XCBInputStream) -> XCBResponse {
-        return [ XCBRawValue.uint(0), XCBRawValue.uint(0), XCBRawValue.uint(0), XCBRawValue.uint(0), XCBRawValue.uint(0), XCBRawValue.uint(0), XCBRawValue.uint(0),
-        XCBRawValue.uint(70),
-        XCBRawValue.uint(0),
-        XCBRawValue.uint(0),
-        XCBRawValue.uint(0),
-        XCBRawValue.string("BUILD_PROGRESS_UPDATED"),
-        XCBRawValue.array([XCBRawValue.string(""), XCBRawValue.string("!to create a life you love ;)     "), XCBRawValue.double(-1.0), XCBRawValue.bool(true)]),
-        XCBRawValue.bool(false)]
-    }
 
     // This currently fails ( could not decode a string )
     static func planningOperationWillStartResponse3(_ input: XCBInputStream) -> XCBResponse {

--- a/notes.txt
+++ b/notes.txt
@@ -1,3 +1,6 @@
+# This is useful to watch where messages end and begin.
+br s -r IDEXCBuildSupport\.IDEXCBuildServiceBuildOperation*
+
 # Use make debug_input and output
 
 


### PR DESCRIPTION
This PR implements handling of build numbers and protocol message
numbering.

Additionally:
- cleanup a few typos in the buildStarted response segment
- add logging to the BS build service