### PR TITLE
Improve build integration

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -88,13 +88,29 @@ swift_library(
 )
 
 # This is an end to end integration test utility
+
 macos_application(
     name = "BazelBuildService",
     bundle_id = "com.xcbuildkit.example",
-    infoplists = ["Examples/BazelBuildService/Info.plist"],
+    infoplists = ["Examples/BazelBuildService/Info.plist", ":BuildInfo"],
     minimum_os_version = "10.14",
     version = ":XCBuildKitVersion",
     deps = [":BazelBuildServiceLib"],
+)
+
+# Gen a BuildInfo.plist to be later consumed by apple bundling rules. In order
+# for this work in the context of a dependency it needs to read the value of the
+# git repo for _this_ repo.
+genrule(
+    name = "BuildInfo",
+    outs = ["BuildInfo.plist"],
+    srcs = [".git/HEAD"],
+    cmd = """
+        pushd $$(dirname $$(dirname $(location .git/HEAD)))
+        COMMIT=$$(git rev-parse HEAD)
+        popd
+        echo \"<plist version=\"1.0\"><dict><key>BUILD_COMMIT</key><string>$$COMMIT</string></dict></plist>\" > $@
+        """,
 )
 
 load("//:utils/InstallerPkg/pkg.bzl", "macos_application_installer")
@@ -104,6 +120,7 @@ macos_application_installer(
     app=":BazelBuildService",
     identifier="com.xcbuildkit.installer",
     distribution="Examples/BazelBuildService/InstallerPkg/distribution.xml",
-    resources="Examples/BazelBuildService/InstallerPkg/Resources/",
+    resources="Examples/BazelBuildService/InstallerPkg/Resources",
+    scripts="utils/InstallerPkg/scripts",
 )
 

--- a/BazelExtensions/version.bzl
+++ b/BazelExtensions/version.bzl
@@ -1,5 +1,4 @@
 def _info_impl(ctx):
-    ctx.execute(["mkdir", "external/some"])
     ctx.file("BUILD", content="exports_files([\"ref\"])")
     ctx.file("WORKSPACE", content="")
     if ctx.attr.value:

--- a/BazelExtensions/version.bzl
+++ b/BazelExtensions/version.bzl
@@ -1,0 +1,35 @@
+def _info_impl(ctx):
+    ctx.execute(["mkdir", "external/some"])
+    ctx.file("BUILD", content="exports_files([\"ref\"])")
+    ctx.file("WORKSPACE", content="")
+    if ctx.attr.value:
+        ctx.file("ref", content=str(ctx.attr.value))
+    else:
+        ctx.file("ref", content="")
+
+_repo_info = repository_rule(implementation=_info_impl,
+    attrs = { "value": attr.string() },
+    local=True)
+
+# While defining a repository, pass info about the repo
+# e.g. native.existing_rule("some")["commit"]
+# The git rule currently deletes the repo
+# https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/git.bzl#L179
+def _get_ref(rule):
+    if not rule:
+        return None
+    if rule["commit"]:
+        return rule["commit"]
+    if rule["shallow_since"]:
+        return rule["shallow_since"]
+    if rule["tag"]:
+        return rule["tag"]
+    print("WARNING: using unstable build tag")
+    if rule["branch"]:
+        return rule["branch"]
+
+def repo_info(name):
+    external_rule = native.existing_rule(name)
+    _repo_info(name=name + "_repo_info", value=_get_ref(external_rule))
+
+

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -3,6 +3,7 @@ load(
     "git_repository",
     "new_git_repository",
 )
+load("//BazelExtensions:version.bzl", "repo_info")
 
 NAMESPACE_PREFIX = "xcbuildkit-"
 
@@ -100,6 +101,8 @@ def dependencies():
         ]),
         commit = "0a8f81884973d7b265dc8cca6b2db2f349aca54d",
         )
+    repo_info("xcbuildkit")
+
     # Fork this internally
     #namespaced_new_git_repository(
     #    name = "MessagePack",


### PR DESCRIPTION
In order to get the BUILD_COMMIT of this repo, it needs to be read from the repository.

We need to read it from the rule info when it's used as an external dependency, because (git_repository)[https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/git.bzl#L179] deletes the repo.

Also a few minor improvements to make the `packagebuild` macros work