### PR TITLE
Install for supported Xcode versions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -120,12 +120,24 @@ genrule(
 
 load("//:utils/InstallerPkg/pkg.bzl", "macos_application_installer")
 
+# We use the xcode-locator to determine what Xcode versions are on the system
+filegroup(
+    name = "BazelBuildServiceInstaller_scripts",
+    srcs = glob(["utils/InstallerPkg/scripts/*"]) +
+        ["@bazel_tools//tools/osx:xcode-locator-genrule"]
+)
+
+filegroup(
+    name = "BazelBuildServiceInstaller_resources",
+    srcs = glob(["Examples/BazelBuildService/InstallerPkg/Resources/*"])
+)
+
 macos_application_installer(
-    name="BazelBuildServiceInstaller",
-    app=":BazelBuildService",
-    identifier="com.xcbuildkit.installer",
-    distribution="Examples/BazelBuildService/InstallerPkg/distribution.xml",
-    resources="Examples/BazelBuildService/InstallerPkg/Resources",
-    scripts="utils/InstallerPkg/scripts",
+    name = "BazelBuildServiceInstaller",
+    app = ":BazelBuildService",
+    identifier = "com.xcbuildkit.installer",
+    distribution = "Examples/BazelBuildService/InstallerPkg/distribution.xml",
+    resources = ":BazelBuildServiceInstaller_resources",
+    scripts = ":BazelBuildServiceInstaller_scripts",
 )
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ install_bazel_progress_bar_support:
 	$(BAZEL) build :BazelBuildServiceInstaller
 	sudo installer -pkg bazel-bin/BazelBuildServiceInstaller.pkg -target /
 
+uninstall_bazel_progress_bar_support:
+	utils/uninstall.sh
+
 # Available dummy targets
 # TODO: add the ability to test all of these
 DUMMY_XCODE_ARGS=-target CLI

--- a/utils/InstallerPkg/pkg.bzl
+++ b/utils/InstallerPkg/pkg.bzl
@@ -40,9 +40,8 @@ def _pkg_impl(ctx):
         scripts_dir = ctx.actions.declare_directory(app_name + "_scripts_dir")
         prepare_scripts_cmd = ["mkdir -p", scripts_dir.path, ";\n"]
         for script in ctx.attr.scripts.files.to_list():
-            # This is no available but requires updating
-            # ctx.actions.symlink(scripts_dir.path, (scripts_dir.path + "/" + script.basename))
-            prepare_scripts_cmd.extend(["ln", script.path, scripts_dir.path + "/" + script.basename + ";\n"])
+            # build may mutate
+            prepare_scripts_cmd.extend(["ditto", script.path, scripts_dir.path + "/" + script.basename + ";\n"])
 
         scripts = ctx.attr.scripts.files.to_list()
         ctx.actions.run_shell(outputs=[scripts_dir], command=" ".join(prepare_scripts_cmd),
@@ -93,9 +92,8 @@ def _product_impl(ctx):
         resources_dir = ctx.actions.declare_directory(ctx.attr.name + "_resources_dir")
         prepare_resources_cmd = ["mkdir -p", resources_dir.path, ";\n"]
         for script in ctx.attr.resources.files.to_list():
-            # This is no available but requires updating
-            # ctx.actions.symlink(resources_dir.path, (resources_dir.path + "/" + script.basename))
-            prepare_resources_cmd.extend(["ln", script.path, resources_dir.path + "/" + script.basename + ";\n"])
+            # build may mutate
+            prepare_resources_cmd.extend(["ditto", script.path, resources_dir.path + "/" + script.basename + ";\n"])
 
         resources = ctx.attr.resources.files.to_list()
         ctx.actions.run_shell(outputs=[resources_dir], command=" ".join(prepare_resources_cmd),

--- a/utils/InstallerPkg/pkg.bzl
+++ b/utils/InstallerPkg/pkg.bzl
@@ -35,9 +35,22 @@ def _pkg_impl(ctx):
 
     inputs = [extracted_app]
     if ctx.attr.scripts:
+        # We need to smash all the scripts into a directory that this can pick
+        # pkgbuild can pick them up
+        scripts_dir = ctx.actions.declare_directory(app_name + "_scripts_dir")
+        prepare_scripts_cmd = ["mkdir -p", scripts_dir.path, ";\n"]
+        for script in ctx.attr.scripts.files.to_list():
+            # This is no available but requires updating
+            # ctx.actions.symlink(scripts_dir.path, (scripts_dir.path + "/" + script.basename))
+            prepare_scripts_cmd.extend(["ln", script.path, scripts_dir.path + "/" + script.basename + ";\n"])
+
         scripts = ctx.attr.scripts.files.to_list()
-        inputs.extend(scripts)
-        cmd.extend(["--scripts", scripts[0].dirname])
+        ctx.actions.run_shell(outputs=[scripts_dir], command=" ".join(prepare_scripts_cmd),
+            inputs=scripts)
+
+        ## Add the scripts_dir to the main command
+        inputs.append(scripts_dir)
+        cmd.extend(["--scripts", scripts_dir.path])
 
     ctx.actions.run_shell(outputs=[ctx.outputs.pkg], command=" ".join(cmd),
         inputs=inputs)
@@ -73,12 +86,25 @@ def _product_impl(ctx):
         ctx.outputs.pkg.path
     ]
     inputs = [distribution, input_pkg]
-    if ctx.attr.resources:
-        resources = ctx.attr.resources.files.to_list()
-        inputs.extend(resources)
-        cmd.extend(["--resources", resources[0].dirname])
 
-    print("Inputs", inputs)
+    if ctx.attr.resources:
+        # We need to smash all the resources into a directory that this can pick
+        # pkgbuild can pick them up
+        resources_dir = ctx.actions.declare_directory(ctx.attr.name + "_resources_dir")
+        prepare_resources_cmd = ["mkdir -p", resources_dir.path, ";\n"]
+        for script in ctx.attr.resources.files.to_list():
+            # This is no available but requires updating
+            # ctx.actions.symlink(resources_dir.path, (resources_dir.path + "/" + script.basename))
+            prepare_resources_cmd.extend(["ln", script.path, resources_dir.path + "/" + script.basename + ";\n"])
+
+        resources = ctx.attr.resources.files.to_list()
+        ctx.actions.run_shell(outputs=[resources_dir], command=" ".join(prepare_resources_cmd),
+            inputs=resources)
+
+        ## Add the resources_dir to the main command
+        inputs.append(resources_dir)
+        cmd.extend(["--resources", resources_dir.path])
+
     ctx.actions.run_shell(outputs=[ctx.outputs.pkg], command=" ".join(cmd),
         inputs=inputs)
 
@@ -98,6 +124,14 @@ macos_application_installer_product = rule(
 def macos_application_installer(**kwargs):
     """
     This macro builds an installer product
+
+    params:
+
+    scripts: a filegroup of scripts. As pkgbuild needs these in 1 single layer,
+    they are flattend during build time
+
+    resources: a filegroup of resources. As product build needs these in 1 single layer,
+    they are flattend during build time 
     """
     scripts = kwargs.pop("scripts")
     install_location = "/opt/XCBuildKit/XCBuildKit.app"
@@ -107,21 +141,11 @@ def macos_application_installer(**kwargs):
     resources  = mkargs.pop("resources")
     distribution = mkargs.pop("distribution")
 
-    native.filegroup(
-        name = name + "_scripts",
-        srcs = native.glob([scripts + "/*"])
-    )
-
     macos_application_installer_pkg(
         name = name + "_impl",
-        scripts=name + "_scripts",
+        scripts=scripts,
         install_location=install_location,
         **mkargs
-    )
-
-    native.filegroup(
-        name = name + "_resources",
-        srcs = native.glob([resources + "/*"])
     )
 
     native.filegroup(
@@ -132,7 +156,7 @@ def macos_application_installer(**kwargs):
     macos_application_installer_product(
         name = name,
         distribution = name + "_distribution",
-        resources = name + "_resources",
+        resources = resources,
         version = "1.0",
         package = name + "_impl"
     )

--- a/utils/InstallerPkg/scripts/postinstall
+++ b/utils/InstallerPkg/scripts/postinstall
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
-# TODO: add version checking here
-# At the moment, the current build works for all Xcode 11 releases
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+
+# Install for Xcode 11 only
+SUPPORTED_VERSION=11
+
 function install_for_xcode() {
     echo "Installing for Xcode $1"
     BS_DEFAULT_LOCATION="${1}/Contents/SharedFrameworks/XCBuild.framework/PlugIns/XCBBuildService.bundle/Contents/MacOS/XCBBuildService"
@@ -19,24 +23,28 @@ function install_for_xcode() {
 
     # Symlink the binary to the default location
     BINARY="$(find "$DSTROOT/Contents/MacOS" -type f | head)"
+    if [[ ! -f "$BINARY" ]]; then
+        echo "Invalid installer $DSTROOT" && exit 1
+    fi
     ln -sf "$BINARY" "$BS_DEFAULT_LOCATION"
 }
 
 function main() {
-    # If the user hasn't selected an Xcode then it won't work
-    XCODE="$(dirname "$(dirname "$(xcode-select -p)")")"
-    install_for_xcode "$XCODE"
+    # Install for all Xcodes for matching version.
+    # See xcode-locator.m for more info
+    ALL_XCODES=( $($SCRIPTPATH/xcode-locator $SUPPORTED_VERSION 2>&1 | \
+        grep "   \"file:" | \
+        sed -e 's, .*"file://,,g' -e 's,"$,,g' -e 's,%20, ,g') )
 
-    # If xcode is running, then install for that Xcode
-    # If install is called 2x it doesn't make a difference
-    RUNNING_XCODES="$(ps ax | grep Contents\/MacOS\/Xcode$ | \
-        awk '{$1=$2=$3=$4="";print substr($0,5) }')"
-    for RUNNING_XCODE in "${RUNNING_XCODES[@]}"; do
-        if [[ -n "$RUNNING_XCODE" ]]; then
-            install_for_xcode "$(dirname "$(dirname "$(dirname "$RUNNING_XCODE")")")"
+    for XCODE in "${ALL_XCODES[@]}"; do
+        echo "XC "$(dirname "$XCODE")""
+        if [[ -n "$XCODE" ]]; then
+            install_for_xcode "$(dirname "$XCODE")"
         fi
     done
 
+    RUNNING_XCODES="$(ps ax | grep Contents\/MacOS\/Xcode$ | \
+        awk '{$1=$2=$3=$4="";print substr($0,5) }')"
     # Attempt to gracefully quit and re-open Xcode
     # Call quit for each instance of Xcode running, and then re-open
     for RUNNING_XCODE in "${RUNNING_XCODES[@]}"; do

--- a/utils/InstallerPkg/scripts/postinstall
+++ b/utils/InstallerPkg/scripts/postinstall
@@ -32,14 +32,12 @@ function install_for_xcode() {
 function main() {
     # Install for all Xcodes for matching version.
     # See xcode-locator.m for more info
-    ALL_XCODES=( $($SCRIPTPATH/xcode-locator $SUPPORTED_VERSION 2>&1 | \
-        grep "   \"file:" | \
-        sed -e 's, .*"file://,,g' -e 's,"$,,g' -e 's,%20, ,g') )
+    ALL_XCODES=( $("$SCRIPTPATH/xcode-locator" 2>&1 | \
+         grep "expanded=$SUPPORTED_VERSION" | sed -e 's,.*file://,,g' -e 's,/:.*,,g') )
 
     for XCODE in "${ALL_XCODES[@]}"; do
-        echo "XC "$(dirname "$XCODE")""
         if [[ -n "$XCODE" ]]; then
-            install_for_xcode "$(dirname "$XCODE")"
+            install_for_xcode "$XCODE"
         fi
     done
 

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+
+SUPPORTED_VERSION=11
+
+function uninstall_for_xcode() {
+    echo "Checking install for Xcode $1"
+    BS_DEFAULT_LOCATION="${1}/Contents/SharedFrameworks/XCBuild.framework/PlugIns/XCBBuildService.bundle/Contents/MacOS/XCBBuildService"
+    # If someone has Xcode selected an invalid Xcode this won't work.
+    if [[ ! -n "$(readlink "$BS_DEFAULT_LOCATION")" ]]; then
+        echo "Not installed for Xcode $1" && return
+    fi
+
+    BS_INSTALLED_LOCATION="${BS_DEFAULT_LOCATION}.default"
+    # Move the original version to the installed location
+    if [[ -f "$BS_INSTALLED_LOCATION" ]]; then
+        echo "Uninstalling for Xcode $1"
+        mv "$BS_INSTALLED_LOCATION" "$BS_DEFAULT_LOCATION" 
+    fi
+}
+
+function main() {
+    # Install for all Xcodes for matching version.
+    # See xcode-locator.m for more info
+    "$SCRIPTPATH/../tools/bazelwrapper" build @bazel_tools//tools/osx:xcode-locator-genrule
+    ALL_XCODES=( $("$SCRIPTPATH/../bazel-bin/external/bazel_tools/tools/osx/xcode-locator" 2>&1 | \
+         grep "expanded=$SUPPORTED_VERSION" | sed -e 's,.*file://,,g' -e 's,/:.*,,g') )
+    for XCODE in "${ALL_XCODES[@]}"; do
+        if [[ -n "$XCODE" ]]; then
+            uninstall_for_xcode "$XCODE"
+        fi
+    done
+}
+
+main "$@"
+

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -8,7 +8,6 @@ SUPPORTED_VERSION=11
 function uninstall_for_xcode() {
     echo "Checking install for Xcode $1"
     BS_DEFAULT_LOCATION="${1}/Contents/SharedFrameworks/XCBuild.framework/PlugIns/XCBBuildService.bundle/Contents/MacOS/XCBBuildService"
-    # If someone has Xcode selected an invalid Xcode this won't work.
     if [[ ! -n "$(readlink "$BS_DEFAULT_LOCATION")" ]]; then
         echo "Not installed for Xcode $1" && return
     fi
@@ -22,9 +21,9 @@ function uninstall_for_xcode() {
 }
 
 function main() {
-    # Install for all Xcodes for matching version.
     # See xcode-locator.m for more info
     "$SCRIPTPATH/../tools/bazelwrapper" build @bazel_tools//tools/osx:xcode-locator-genrule
+    # Prints a list of [Xcode.app]
     ALL_XCODES=( $("$SCRIPTPATH/../bazel-bin/external/bazel_tools/tools/osx/xcode-locator" 2>&1 | \
          grep "expanded=$SUPPORTED_VERSION" | sed -e 's,.*file://,,g' -e 's,/:.*,,g') )
     for XCODE in "${ALL_XCODES[@]}"; do


### PR DESCRIPTION
We don't want to enable this for Xcode versions which aren't supported

It uses the xcode-locator bin to determine what Xcodes we should install
for.

Additionally, improve the pgkbuild rules to allow for this