### PR TITLE
Simplify streaming BEP binary protobuf for Xcode progress bar

### DIFF
--- a/Examples/BazelBuildService/BEPStream.swift
+++ b/Examples/BazelBuildService/BEPStream.swift
@@ -7,7 +7,6 @@ public typealias BEPReadHandler = (BuildEventStream_BuildEvent) -> Void
 
 public class BEPStream {
     private let path: String
-    private var hitLastMessage: Bool = false
     private var fileHandle: FileHandle?
 
     /// @param path - Binary BEP file
@@ -66,10 +65,6 @@ public class BEPStream {
                     let info = try BinaryDelimited.parse(messageType:
                         BuildEventStream_BuildEvent.self, from: input)
                     handler(info)
-                    if info.lastMessage {
-                        self.hitLastMessage = true
-                    }
-
                     log("BEPStream read event \(fileHandle.offsetInFile)")
                 } catch {
                     log("BEPStream read error: " + error.localizedDescription)

--- a/Examples/BazelBuildService/BEPStream.swift
+++ b/Examples/BazelBuildService/BEPStream.swift
@@ -6,11 +6,9 @@ import XCBProtocol
 public typealias BEPReadHandler = (BuildEventStream_BuildEvent) -> Void
 
 public class BEPStream {
-    private let readQueue = DispatchQueue(label: "com.bkbuildservice.bepstream")
     private let path: String
-    private var input: InputStream!
-    private var lastMTime: TimeInterval?
     private var hitLastMessage: Bool = false
+    private var fileHandle: FileHandle?
 
     /// @param path - Binary BEP file
     /// this is passed to Bazel via --build_event_binary_file
@@ -22,52 +20,65 @@ public class BEPStream {
     /// @param eventAvailableHandler - this is called with _every_ BEP event
     /// available
     public func read(eventAvailableHandler handler: @escaping BEPReadHandler) throws {
-        input = InputStream(fileAtPath: path)!
-        readQueue.async {
-            self.input.open()
-            self.readLoop(eventAvailableHandler: handler)
-        }
-    }
+        let fm = FileManager.default
+        // Bazel works by appending content to a file, specifically,
+        // Java'sBufferedOutputStream.
+        // Naievely using an input stream for the path and waiting for available
+        // data will simply does not work with whatever
+        // BufferedOutputStream.flush() is doing internally.
+        // 
+        // Reference:
+        // https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java
+        // Perhaps, SwiftProtobuf can come up with a better solution to read
+        // from files or upstream similar code
+        // https://github.com/apple/swift-protobuf/issues/130
+        //
+        // Logic:
+        // - If there's already a file at the path remove it
+        // - Create a few file
+        // - When the build starts, Bazel will attempt to reuse the inode, and
+        //   stream to it.
+        //
+        //   Then,
+        // - Via NSFileHandle, wait for data to be available and read all the
+        //   bytes
+        try? fm.removeItem(atPath: path)
+        try fm.createFile(atPath: path, contents: Data())
 
-    private func readLoop(eventAvailableHandler handler: @escaping BEPReadHandler) {
-        while !hitLastMessage {
-            if input.hasBytesAvailable {
+        guard let fileHandle = FileHandle(forReadingAtPath: path) else {
+            log("BEPStream: failed to allocate \(path)")
+            return
+        }
+        if let existingHandle = self.fileHandle {
+            existingHandle.closeFile()
+        }
+        self.fileHandle = fileHandle
+        fileHandle.readabilityHandler = {
+            handle in
+            let data = fileHandle.availableData
+            guard data.count > 0 else {
+                return
+            }
+
+            // Wrap the file handle in an InputStream for SwiftProtobuf to read
+            // we read the stream until the end of the file
+            let input = InputStream(data: data)
+            input.open()
+            while input.hasBytesAvailable {
                 do {
                     let info = try BinaryDelimited.parse(messageType:
                         BuildEventStream_BuildEvent.self, from: input)
                     handler(info)
-
-                    // When we hit the last message close the stream and end
                     if info.lastMessage {
-                        hitLastMessage = true
-                        input.close()
-                        break
+                        self.hitLastMessage = true
                     }
+
+                    log("BEPStream read event \(fileHandle.offsetInFile)")
                 } catch {
-                    log("BEPReadError" + error.localizedDescription)
-                    input.close()
+                    log("BEPStream read error: " + error.localizedDescription)
+                    break
                 }
-            } else {
-                // Wait until the BEP file is available
-                // FIXME: replace polling with kqueue or better
-                if hasChanged() {
-                    try! read(eventAvailableHandler: handler)
-                    return
-                }
-                sleep(1)
             }
         }
-    }
-
-    private func hasChanged() -> Bool {
-        let url = URL(fileURLWithPath: path)
-        let resourceValues = try? url.resourceValues(forKeys:
-            Set([.contentModificationDateKey]))
-        let mTime = resourceValues?.contentModificationDate?.timeIntervalSince1970 ?? 0
-        if mTime != lastMTime {
-            lastMTime = mTime
-            return true
-        }
-        return false
     }
 }

--- a/Examples/BazelBuildService/BEPStream.swift
+++ b/Examples/BazelBuildService/BEPStream.swift
@@ -49,9 +49,6 @@ public class BEPStream {
             log("BEPStream: failed to allocate \(path)")
             return
         }
-        if let existingHandle = self.fileHandle {
-            existingHandle.closeFile()
-        }
         self.fileHandle = fileHandle
         fileHandle.readabilityHandler = {
             handle in

--- a/Examples/BazelBuildService/main.swift
+++ b/Examples/BazelBuildService/main.swift
@@ -17,7 +17,6 @@ var gStream: BEPStream?
 enum BasicMessageHandler {
     static func startStream(bepPath: String, startBuildInput: XCBInputStream, bkservice: BKBuildService) throws {
         log("startStream " + String(describing: startBuildInput))
-        try? FileManager.default.removeItem(atPath: bepPath)
         let stream = try BEPStream(path: bepPath)
         var progressView: ProgressView?
         try stream.read {


### PR DESCRIPTION
Move BEP event reading to allocating an InputStream per read, via
NSFileHandle.readabilityHandler.

Bazel works by appending content to a file, specifically,
Java'sBufferedOutputStream.  Naievely using an input stream for the path
and waiting for available data will simply does not work with whatever
BufferedOutputStream.flush() is doing internally.

Reference:
https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java

Perhaps, SwiftProtobuf can come up with a better solution to read
from files or upstream similar code
https://github.com/apple/swift-protobuf/issues/130

Logic:
- If there's already a file at the path remove it
- Create a few file
- When the build starts, Bazel will attempt to reuse the inode, and
  stream to it.
  Then,
- Via NSFileHandle, wait for data to be available and read all the
  bytes