### PR TITLE
Prevent fatal error when writing progress response

### DIFF
--- a/Examples/BazelBuildService/main.swift
+++ b/Examples/BazelBuildService/main.swift
@@ -25,7 +25,7 @@ enum BasicMessageHandler {
                 let encoder = XCBEncoder(input: startBuildInput)
                 let response = BuildProgressUpdatedResponse(progress:
                     updatedView.progressPercent, message: updatedView.message)
-                if let responseData = try? message.encode(encoder) {
+                if let responseData = try? response.encode(encoder) {
                      bkservice.write(responseData)
                 }
                 progressView = updatedView

--- a/Examples/BazelBuildService/main.swift
+++ b/Examples/BazelBuildService/main.swift
@@ -25,7 +25,9 @@ enum BasicMessageHandler {
                 let encoder = XCBEncoder(input: startBuildInput)
                 let response = BuildProgressUpdatedResponse(progress:
                     updatedView.progressPercent, message: updatedView.message)
-                bkservice.write(try! response.encode(encoder))
+                if let responseData = try? message.encode(encoder) {
+                     bkservice.write(responseData)
+                }
                 progressView = updatedView
             }
         }


### PR DESCRIPTION
This was missed in the last PR. This triggers when there's errors in Xcode