### PR TITLE
[Stability] Prevent UInt64 underflow on writing messages

### DIFF
--- a/Examples/BazelBuildService/BEPStream.swift
+++ b/Examples/BazelBuildService/BEPStream.swift
@@ -42,7 +42,7 @@ public class BEPStream {
         // - Via NSFileHandle, wait for data to be available and read all the
         //   bytes
         try? fm.removeItem(atPath: path)
-        try fm.createFile(atPath: path, contents: Data())
+        fm.createFile(atPath: path, contents: Data())
 
         guard let fileHandle = FileHandle(forReadingAtPath: path) else {
             log("BEPStream: failed to allocate \(path)")

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -16,7 +16,7 @@ public class XCBEncoder {
             // This happens when there is unexpected input. There is an
             // unimplemented where this does happen, triggered by
             // BazelBuildService.
-            log("missing id")
+            log("missing id for msg: " String(describing: self.input))
             throw XCBProtocolError.unexpectedInput(for: self.input)
         }
         return id + 1

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -95,9 +95,11 @@ public func log(_ str: String) {
     do {
         let fileUpdater = try FileHandle(forWritingTo: url)
         fileUpdater.seekToEndOfFile()
-        fileUpdater.write(entry.data(using: .utf8)!)
+        if let data = entry.data(using: .utf8) {
+            fileUpdater.write(data)
+        }
         fileUpdater.closeFile()
     } catch {
-        try! entry.write(to: url, atomically: false, encoding: .utf8)
+        try? entry.write(to: url, atomically: false, encoding: .utf8)
     }
 }

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -16,7 +16,7 @@ public class XCBEncoder {
             // This happens when there is unexpected input. There is an
             // unimplemented where this does happen, triggered by
             // BazelBuildService.
-            log("missing id for msg: " String(describing: self.input))
+            log("missing id for msg: " + String(describing: self.input))
             throw XCBProtocolError.unexpectedInput(for: self.input)
         }
         return id + 1

--- a/Sources/XCBProtocol/Packer.swift
+++ b/Sources/XCBProtocol/Packer.swift
@@ -2,14 +2,6 @@ import Foundation
 import MessagePack
 
 extension FixedWidthInteger {
-    init(bytes: [UInt8]) {
-        self = bytes.withUnsafeBufferPointer {
-            $0.baseAddress!.withMemoryRebound(to: Self.self, capacity: 1) {
-                $0.pointee
-            }
-        }.bigEndian
-    }
-
     var bytes: [UInt8] {
         let capacity = MemoryLayout<Self>.size
         var mutableValue = bigEndian

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -24,7 +24,7 @@ private extension XCBEncoder {
         // far. Guard against possible integer underflow
         let id = try getMsgId()
         guard id >= offset else {
-            log("bad offset for msg: " String(describing: self.input))
+            log("bad offset for msg: " + String(describing: self.input))
             throw XCBProtocolError.unexpectedInput(for: self.input)
         }
         return id - offset

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -24,7 +24,7 @@ private extension XCBEncoder {
         // far. Guard against possible integer underflow
         let id = try getMsgId()
         guard id >= offset else {
-            log("bad offset")
+            log("bad offset for msg: " String(describing: self.input))
             throw XCBProtocolError.unexpectedInput(for: self.input)
         }
         return id - offset

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -17,6 +17,21 @@ let XCBProtocolVersion = "11"
 /// find a better solution
 private var gBuildNumber: Int64 = -1
 
+private extension XCBEncoder {
+    func getResponseMsgId(subtracting  offset: UInt64) throws -> UInt64 {
+        // FIXME: consider finding ways to mitigate unexpected input in
+        // upstream code.
+        // There is some possible ways that bad messages will make it this far
+        // down the code, and this code guards against integer overflow
+        let id = try getMsgId()
+        guard id >= offset else {
+            log("bad offset")
+            throw XCBProtocolError.unexpectedInput(for: self.input)
+        }
+        return id - offset
+    }
+}
+
 public struct CreateSessionRequest: XCBProtocolMessage {
     public let workspace: String
     public let xcode: String
@@ -245,7 +260,7 @@ public struct BuildStartResponse: XCBProtocolMessage {
             XCBRawValue.uint(0),
             XCBRawValue.string("BOOL"),
             XCBRawValue.array([XCBRawValue.bool(true)]),
-            XCBRawValue.uint(try encoder.getMsgId() - 3),
+            XCBRawValue.uint(try encoder.getResponseMsgId(subtracting: 3)),
             // END
         ]
     }
@@ -270,7 +285,7 @@ public struct BuildProgressUpdatedResponse: XCBProtocolMessage {
         let padding = 14 // sizeof messages, random things
         let length = "BUILD_PROGRESS_UPDATED".utf8.count + self.taskName.utf8.count + self.message.utf8.count
         return [
-            XCBRawValue.uint(try encoder.getMsgId() - 3),
+            XCBRawValue.uint(try encoder.getResponseMsgId(subtracting: 3)),
             XCBRawValue.uint(0),
             XCBRawValue.uint(0),
             XCBRawValue.uint(0),
@@ -300,7 +315,7 @@ public struct PlanningOperationWillStartResponse: XCBProtocolMessage {
             XCBRawValue.uint(0),
             XCBRawValue.string("PLANNING_OPERATION_WILL_START"),
             XCBRawValue.array([XCBRawValue.string("S0"), XCBRawValue.string("FC5F5C50-8B9C-43D6-8F5A-031E967F5CC0")]),
-            XCBRawValue.uint(try encoder.getMsgId() - 3),
+            XCBRawValue.uint(try encoder.getResponseMsgId(subtracting: 3)),
         ]
     }
 }
@@ -317,7 +332,7 @@ public struct PlanningOperationWillEndResponse: XCBProtocolMessage {
             XCBRawValue.uint(0),
             XCBRawValue.string("PLANNING_OPERATION_FINISHED"),
             XCBRawValue.array([XCBRawValue.string("S0"), XCBRawValue.string("FC5F5C50-8B9C-43D6-8F5A-031E967F5CC0")]),
-            XCBRawValue.uint(try encoder.getMsgId() - 3),
+            XCBRawValue.uint(try encoder.getResponseMsgId(subtracting: 3)),
         ]
     }
 }

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -19,10 +19,9 @@ private var gBuildNumber: Int64 = -1
 
 private extension XCBEncoder {
     func getResponseMsgId(subtracting  offset: UInt64) throws -> UInt64 {
-        // FIXME: consider finding ways to mitigate unexpected input in
-        // upstream code.
-        // There is some possible ways that bad messages will make it this far
-        // down the code, and this code guards against integer overflow
+        // Consider finding ways to mitigate unexpected input in upstream code.
+        // There may be possible ways that unexpected messages will make it this
+        // far. Guard against possible integer underflow
         let id = try getMsgId()
         guard id >= offset else {
             log("bad offset")


### PR DESCRIPTION
Fix _classic_ integer handling programming error: If encoder.getMsgId() is < 3 it will EXC_BAD_INSTRUCTION (SIGILL).

I introduced a helper function to detect and prevent this error, which
makes sure that it won't overflow if used.

Additionally remove all force unwraps and misc dead code in the main code