### PR TITLE
Fix a small compilation bug

### DIFF
--- a/BuildServiceShim/main.c
+++ b/BuildServiceShim/main.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 int main(int ac, char** av) {
     // Run a bash script "stub" adjacent to the binary
     system("/bin/bash -c \"$(dirname $XCBBUILDSERVICE_PATH)/BuildServiceShim.runfiles/__main__/BuildServiceShim/stub.sh\"");


### PR DESCRIPTION
```
BuildServiceShim/main.c:3:5: error: implicit declaration of function 'system' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    system("/bin/bash -c \"$(dirname $XCBBUILDSERVICE_PATH)/BuildServiceShim.runfiles/__main__/BuildServiceShim/stub.sh\"");
    ^
1 error generated.
```