### PR TITLE
update bazel to 4.22, rules_apple(0.32.0) and rules_swift(0.24)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
 )
 
 load(
@@ -12,10 +12,12 @@ load(
     "apple_rules_dependencies",
 )
 
-git_repository(
+apple_rules_dependencies()
+
+http_archive(
     name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    commit = "0192f16b82b2998d846c45187545e38548a6671a",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
+    sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
 )
 
 load(
@@ -25,8 +27,12 @@ load(
 
 swift_rules_dependencies()
 
-apple_rules_dependencies()
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
 
+swift_rules_extra_dependencies()
 
 load(
     "@build_bazel_apple_support//lib:repositories.bzl",
@@ -42,7 +48,6 @@ load(
 
 protobuf_deps()
 
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(
@@ -54,4 +59,3 @@ http_file(
 load("//third_party:repositories.bzl", "dependencies")
 
 dependencies()
-

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="4.2.2"
+BAZEL_VERSION_SHA="1ff0fa7ec14bdeda3ec3757d15fa0eff6604313ab734f347157006489dc04383"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 


### PR DESCRIPTION
this is required when update xchammer 