### PR TITLE
Bump to Bazel 5.0.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 build \
  --spawn_strategy=standalone \
  --strategy=SwiftCompile=worker \
- --experimental_strict_action_env=true \
+ --incompatible_strict_action_env=1 \
  --build_event_binary_file=/tmp/bep.bep

--- a/BuildServiceShim/stub.sh
+++ b/BuildServiceShim/stub.sh
@@ -3,7 +3,7 @@
 # The service is adjacent to this program
 # The layer of indirection is useful for debugging and not
 # a production component
-SERVICE="$(dirname $(dirname $XCBBUILDSERVICE_PATH))/BazelBuildService-intermediates/BazelBuildService"
+SERVICE="$(dirname $(dirname $XCBBUILDSERVICE_PATH))/BazelBuildService_app_dir/BazelBuildService.app/Contents/MacOS/BazelBuildService"
 
 function redirect() {
     #tee  >($SERVICE) /tmp/xcbuild.out

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="4.2.2"
-BAZEL_VERSION_SHA="1ff0fa7ec14bdeda3ec3757d15fa0eff6604313ab734f347157006489dc04383"
+BAZEL_VERSION="5.0.0"
+BAZEL_VERSION_SHA="f7e8d1eac85ec125c430f9553e35d522c057895262956201ccea8a27d87054cc"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 


### PR DESCRIPTION
Noticed that `make` development commands were failing for different reasons, haven't spent much time digging into it since it looked like lack of compatibility with latest tools in general. We have two options here (1) dig on the current setup and try to fix things up (2) simply bump Bazel since issues go away by doing that, only risk here is if there's something else that needs to be migrated besides what I tested.

With this change `make` commands are now working, e.g. `make test`, `make open_xcode`, etc.