### PR TITLE
Fix dsym build and tree artifacts, bump rules_{apple,swift}, buildifier lint

### DIFF
--- a/BazelExtensions/version.bzl
+++ b/BazelExtensions/version.bzl
@@ -1,14 +1,16 @@
 def _info_impl(ctx):
-    ctx.file("BUILD", content="exports_files([\"ref\"])")
-    ctx.file("WORKSPACE", content="")
+    ctx.file("BUILD", content = "exports_files([\"ref\"])")
+    ctx.file("WORKSPACE", content = "")
     if ctx.attr.value:
-        ctx.file("ref", content=str(ctx.attr.value))
+        ctx.file("ref", content = str(ctx.attr.value))
     else:
-        ctx.file("ref", content="")
+        ctx.file("ref", content = "")
 
-_repo_info = repository_rule(implementation=_info_impl,
-    attrs = { "value": attr.string() },
-    local=True)
+_repo_info = repository_rule(
+    implementation = _info_impl,
+    attrs = {"value": attr.string()},
+    local = True,
+)
 
 # While defining a repository, pass info about the repo
 # e.g. native.existing_rule("some")["commit"]
@@ -27,6 +29,4 @@ def _get_ref(rule):
 
 def repo_info(name):
     external_rule = native.existing_rule(name)
-    _repo_info(name=name + "_repo_info", value=_get_ref(external_rule))
-
-
+    _repo_info(name = name + "_repo_info", value = _get_ref(external_rule))

--- a/BuildServiceShim/BUILD
+++ b/BuildServiceShim/BUILD
@@ -2,7 +2,7 @@
 # It's not useful for production
 cc_binary(
     name = "main",
-    srcs = ["main.c"]
+    srcs = ["main.c"],
 )
 
 sh_binary(
@@ -10,4 +10,3 @@ sh_binary(
     srcs = [":main"],
     data = glob(["*.sh"]),
 )
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-http_archive(
+git_repository(
     name = "build_bazel_rules_apple",
-    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
+    commit = "7115f0188d141d57d64a6875735847c975956dae",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    shallow_since = "1648060786 -0700",
 )
 
 load(
@@ -14,10 +15,11 @@ load(
 
 apple_rules_dependencies()
 
-http_archive(
+git_repository(
     name = "build_bazel_rules_swift",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
-    sha256 = "4f167e5dbb49b082c5b7f49ee688630d69fb96f15c84c448faa2e97a5780dbbc",
+    commit = "22192877498705ff1adbecd820fdc2724414b0b2",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    shallow_since = "1649264039 -0700",
 )
 
 load(
@@ -47,8 +49,6 @@ load(
 )
 
 protobuf_deps()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(
     name = "xctestrunner",

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -64,7 +64,7 @@ swift_c_module(
         module_map = module_map,
     ))
 
-def namespaced_swift_library(name, srcs, deps = None, defines = None, copts=[]):
+def namespaced_swift_library(name, srcs, deps = None, defines = None, copts = []):
     deps = [] if deps == None else deps
     defines = [] if defines == None else defines
     return """
@@ -100,7 +100,7 @@ def dependencies():
             ),
         ]),
         commit = "0a8f81884973d7b265dc8cca6b2db2f349aca54d",
-        )
+    )
     repo_info("xcbuildkit")
 
     # Fork this internally

--- a/third_party/xcbuildkit-MessagePack/BUILD.bazel
+++ b/third_party/xcbuildkit-MessagePack/BUILD.bazel
@@ -1,13 +1,15 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
 
 package(default_visibility = ["//visibility:public"])
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_c_module",
-"swift_library")
 
 swift_library(
     name = "MessagePack",
     srcs = glob(["Sources/**/*.swift"]),
+    copts = ["-DSWIFT_PACKAGE"],
+    defines = [],
     module_name = "MessagePack",
     deps = [],
-    defines = [],
-    copts = ["-DSWIFT_PACKAGE", ],
 )

--- a/utils/InstallerPkg/pkg.bzl
+++ b/utils/InstallerPkg/pkg.bzl
@@ -1,24 +1,30 @@
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
+
 def _pkg_impl(ctx):
     # Use the name of the app
     # This relies on the convention of macos_application
     app_name = ctx.attr.app.label.name
     extracted_app = ctx.actions.declare_directory(app_name + "_app_dir")
 
-    # Bazel givs us the .app as a zip file.
+    # Bazel gives us the .app as a zip file.
     # Unzip so we can directly package the .app
+    bundle_zip = ctx.attr.app[AppleBundleInfo].archive
     unzip_cmd = [
         "mkdir -p " + extracted_app.path + ";",
-        "unzip", 
-        "-q", 
-        ctx.expand_location("$(location " + str(ctx.attr.app.label) + ")", targets=[ctx.attr.app]),
+        "unzip",
+        "-q",
+        bundle_zip.path,
         "-d",
         extracted_app.path,
     ]
-    ctx.actions.run_shell(inputs=ctx.attr.app.files, outputs=[extracted_app],
-        command=" ".join(unzip_cmd))
+    ctx.actions.run_shell(
+        inputs = ctx.attr.app.files,
+        outputs = [extracted_app],
+        command = " ".join(unzip_cmd),
+    )
 
     cmd = [
-        "pkgbuild", 
+        "pkgbuild",
         "--root",
         # This puts the .app at the root of the package
         # And causes the install_location to be the name of the app.
@@ -28,9 +34,9 @@ def _pkg_impl(ctx):
         ctx.attr.identifier,
         "--version",
         ctx.attr.version,
-
-        "--install-location", ctx.attr.install_location,
-        ctx.outputs.pkg.path
+        "--install-location",
+        ctx.attr.install_location,
+        ctx.outputs.pkg.path,
     ]
 
     inputs = [extracted_app]
@@ -44,15 +50,21 @@ def _pkg_impl(ctx):
             prepare_scripts_cmd.extend(["ditto", script.path, scripts_dir.path + "/" + script.basename + ";\n"])
 
         scripts = ctx.attr.scripts.files.to_list()
-        ctx.actions.run_shell(outputs=[scripts_dir], command=" ".join(prepare_scripts_cmd),
-            inputs=scripts)
+        ctx.actions.run_shell(
+            outputs = [scripts_dir],
+            command = " ".join(prepare_scripts_cmd),
+            inputs = scripts,
+        )
 
         ## Add the scripts_dir to the main command
         inputs.append(scripts_dir)
         cmd.extend(["--scripts", scripts_dir.path])
 
-    ctx.actions.run_shell(outputs=[ctx.outputs.pkg], command=" ".join(cmd),
-        inputs=inputs)
+    ctx.actions.run_shell(
+        outputs = [ctx.outputs.pkg],
+        command = " ".join(cmd),
+        inputs = inputs,
+    )
 
 # Consider implementing this into rules apple or more generally
 # https://github.com/bazelbuild/rules_pkg/tree/master/pkg
@@ -60,13 +72,13 @@ def _pkg_impl(ctx):
 macos_application_installer_pkg = rule(
     implementation = _pkg_impl,
     attrs = {
-        "app" : attr.label(),
+        "app": attr.label(providers = [AppleBundleInfo]),
         "identifier": attr.string(),
-        "version": attr.string(default="1.0"),
+        "version": attr.string(default = "1.0"),
         "install_location": attr.string(),
         "scripts": attr.label(),
     },
-    outputs = { "pkg": "%{name}.pkg" }
+    outputs = {"pkg": "%{name}.pkg"},
 )
 
 def _product_impl(ctx):
@@ -75,14 +87,14 @@ def _product_impl(ctx):
     input_pkg = ctx.attr.package.files.to_list()[0]
     distribution = ctx.attr.distribution.files.to_list()[0]
     cmd = [
-        "productbuild", 
+        "productbuild",
         "--distribution",
         distribution.path,
         "--version",
         ctx.attr.version,
         "--package-path",
         input_pkg.dirname,
-        ctx.outputs.pkg.path
+        ctx.outputs.pkg.path,
     ]
     inputs = [distribution, input_pkg]
 
@@ -96,28 +108,33 @@ def _product_impl(ctx):
             prepare_resources_cmd.extend(["ditto", script.path, resources_dir.path + "/" + script.basename + ";\n"])
 
         resources = ctx.attr.resources.files.to_list()
-        ctx.actions.run_shell(outputs=[resources_dir], command=" ".join(prepare_resources_cmd),
-            inputs=resources)
+        ctx.actions.run_shell(
+            outputs = [resources_dir],
+            command = " ".join(prepare_resources_cmd),
+            inputs = resources,
+        )
 
         ## Add the resources_dir to the main command
         inputs.append(resources_dir)
         cmd.extend(["--resources", resources_dir.path])
 
-    ctx.actions.run_shell(outputs=[ctx.outputs.pkg], command=" ".join(cmd),
-        inputs=inputs)
+    ctx.actions.run_shell(
+        outputs = [ctx.outputs.pkg],
+        command = " ".join(cmd),
+        inputs = inputs,
+    )
 
 # Builds packagebuild product
 macos_application_installer_product = rule(
     implementation = _product_impl,
     attrs = {
-        "distribution" : attr.label(allow_single_file=True),
-        "resources": attr.label(allow_single_file=True),
+        "distribution": attr.label(allow_single_file = True),
+        "resources": attr.label(allow_single_file = True),
         "version": attr.string(),
-        "package": attr.label(allow_single_file=True),
+        "package": attr.label(allow_single_file = True),
     },
-    outputs = { "pkg": "%{name}.pkg" }
+    outputs = {"pkg": "%{name}.pkg"},
 )
-
 
 def macos_application_installer(**kwargs):
     """
@@ -129,26 +146,26 @@ def macos_application_installer(**kwargs):
     they are flattend during build time
 
     resources: a filegroup of resources. As product build needs these in 1 single layer,
-    they are flattend during build time 
+    they are flattend during build time
     """
     scripts = kwargs.pop("scripts")
     install_location = "/opt/XCBuildKit/XCBuildKit.app"
     mkargs = kwargs
     name = mkargs.pop("name")
 
-    resources  = mkargs.pop("resources")
+    resources = mkargs.pop("resources")
     distribution = mkargs.pop("distribution")
 
     macos_application_installer_pkg(
         name = name + "_impl",
-        scripts=scripts,
-        install_location=install_location,
+        scripts = scripts,
+        install_location = install_location,
         **mkargs
     )
 
     native.filegroup(
         name = name + "_distribution",
-        srcs = native.glob([distribution])
+        srcs = native.glob([distribution]),
     )
 
     macos_application_installer_product(
@@ -156,5 +173,5 @@ def macos_application_installer(**kwargs):
         distribution = name + "_distribution",
         resources = resources,
         version = "1.0",
-        package = name + "_impl"
+        package = name + "_impl",
     )


### PR DESCRIPTION
xchammer wasn't buildable with dsym generation. It looks like it was mostly due to the `expand_location` unexpectedly getting multiple locations. I changed it to be more idiomatic with the provider to the correct output.

While I was experimenting, I also bumped the rules to match the current commits in rules-ios and xchammer. Since I touched a bunch of bzl/BUILD files, I also ran buildifier on the whole repo just to clean things up a bit.

Also tweaked things a bit more to allow for `--define=apple.experimental.tree_artifact_outputs=1`