### PR TITLE
Adds human readable debug messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BUILD_SERVICE=BazelBuildService
 
 .PHONY: build
 build:
-	$(BAZEL) build :* //BuildServiceShim
+	$(BAZEL) build :* //BuildServiceShim $(BUILD_SERVICE)
 
 # Note: after using launchd to set an env var, apps that use it need to be
 # relaunched: Xcode / terminals
@@ -28,7 +28,6 @@ uninstall_bazel_progress_bar_support:
 DUMMY_XCODE_ARGS=-target CLI
 # DUMMY_XCODE_ARGS=-target iOSApp -sdk iphonesimulator
 test: build
-	$(BAZEL) build $(BUILD_SERVICE)
 	rm -rf /tmp/xcbuild.*
 	/usr/bin/env - TERM="$(TERM)" \
 		SHELL="$(SHELL)" \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ XCB=$(XCODE)/Contents/Developer/usr/bin/xcodebuild
 # The shim isn't used in production
 XCBBUILDSERVICE_PATH=$(PWD)/bazel-bin/BuildServiceShim/BuildServiceShim
 
+# Build service to use when running `test` and `debug_*` actions below
+BUILD_SERVICE=BazelBuildService
+
 .PHONY: build
 build:
 	$(BAZEL) build :* //BuildServiceShim
@@ -25,7 +28,7 @@ uninstall_bazel_progress_bar_support:
 DUMMY_XCODE_ARGS=-target CLI
 # DUMMY_XCODE_ARGS=-target iOSApp -sdk iphonesimulator
 test: build
-	$(BAZEL) build BSBuildService
+	$(BAZEL) build $(BUILD_SERVICE)
 	rm -rf /tmp/xcbuild.*
 	/usr/bin/env - TERM="$(TERM)" \
 		SHELL="$(SHELL)" \
@@ -45,8 +48,8 @@ open_xcode: build
 	    export PATH="$(PATH)"; \
 	    export HOME="$(HOME)"; \
 	    export XCODE="$(XCODE)"; \
-	    export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
-             $(XCODE)/Contents/MacOS/Xcode
+			export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
+      $(XCODE)/Contents/MacOS/Xcode
 
 clean:
 	rm -rf /tmp/xcbuild.*
@@ -75,15 +78,25 @@ hex_dump:
 dump:
 	echo "print(repr(open('$(FILE)', 'rb').read()))" | python
 
-# Dumps the parsed stream
-debug_output:
+# Dumps raw values from the parsed output stream
+debug_output_raw:
 	@cat /tmp/xcbuild.out | \
-	    $(BAZEL) run BSBuildService -- --dump
+	    $(BAZEL) run $(BUILD_SERVICE) -- --dump
 
-# Dumps the parsed stream
-debug_input:
+# Dumps raw values from the parsed input stream
+debug_input_raw:
 	@cat /tmp/xcbuild.in | \
-	    $(BAZEL) run BSBuildService -- --dump
+	    $(BAZEL) run $(BUILD_SERVICE) -- --dump
+
+# Dumps human readable values from the parsed output stream
+debug_output_h:
+	@cat /tmp/xcbuild.out | \
+	    $(BAZEL) run $(BUILD_SERVICE) -- --dump_h
+
+# Dumps human readable values from the parsed input stream
+debug_input_h:
+	@cat /tmp/xcbuild.in | \
+	    $(BAZEL) run $(BUILD_SERVICE) -- --dump_h
 
 debug_output_python: build
 	@cat /tmp/xcbuild.out | utils/msgpack_dumper.py

--- a/Sources/BKBuildService/BPlistConverter.swift
+++ b/Sources/BKBuildService/BPlistConverter.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// Credits to: https://gist.github.com/ngbaanh/7c437d99bea75161a59f5af25be99de4
+class BPlistConverter {
+    struct PlistMimeType {
+        static let xmlPlist    = "text/x-apple-plist+xml"
+        static let binaryPlist = "application/x-apple-binary-plist"
+    }
+
+    //// Visible Stuffs ////////////////////////////////////////////////////////
+    convenience init?(binaryData: Data, quiet: Bool = true) {
+        self.init(binaryData, format: .binaryFormat_v1_0, quiet: quiet)
+    }
+
+    convenience init?(xml: String, quiet: Bool = true) {
+        guard let xmlData = xml.data(using: .utf8) else { return nil }
+        self.init(xmlData, format: .xmlFormat_v1_0, quiet: quiet)
+    }
+
+    func convertToXML() -> String? {
+        guard let xmlData = convert(to: .xmlFormat_v1_0) else { return nil }
+        return String.init(data: xmlData, encoding: .utf8)
+    }
+
+    func convertToBinary() -> Data? {
+        return convert(to: .binaryFormat_v1_0)
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //// Private ///////////////////////////////////////////////////////////////
+    private var plist: CFPropertyList?                                        //
+                                                                              //
+    private init?(_ data: Data,                                               //
+                    format: CFPropertyListFormat,                             //
+                    quiet: Bool = true) {                                     //
+        var dataBytes = Array(data)                                           //
+        let plistCoreData = CFDataCreate(kCFAllocatorDefault,                 //
+                                         &dataBytes, dataBytes.count)         //
+                                                                              //
+        var error: Unmanaged<CFError>?                                        //
+        var inputFormat = format                                              //
+        let options = CFPropertyListMutabilityOptions                         //
+                            .mutableContainersAndLeaves.rawValue              //
+        plist = CFPropertyListCreateWithData(kCFAllocatorDefault,             //
+                                             plistCoreData,                   //
+                                             options,                         //
+                                             &inputFormat,                    //
+                                             &error)?.takeUnretainedValue()   //
+        guard plist != nil, nil == error else {                               //
+            if !quiet {                                                       //
+                print("Error on CFPropertyListCreateWithData : ",             //
+                  error!.takeUnretainedValue(), "Return nil")                 //
+            }                                                                 //
+            error?.release()                                                  //
+            return nil                                                        //
+        }                                                                     //
+        error?.release()                                                      //
+    }                                                                         //
+                                                                              //
+    private func convert(to format: CFPropertyListFormat) -> Data? {          //
+        var error: Unmanaged<CFError>?                                        //
+        let binary = CFPropertyListCreateData(kCFAllocatorDefault,            //
+                                              plist, format,                  //
+                                              0, // unused, set 0             //
+                                              &error)?.takeUnretainedValue()  //
+        let data = Data.init(bytes: CFDataGetBytePtr(binary),                 //
+                             count: CFDataGetLength(binary))                  //
+        error?.release()                                                      //
+        return data                                                           //
+    }                                                                         //
+                                                                              //
+    ////////////////////////////////////////////////////////////////////////////
+}

--- a/Sources/BKBuildService/PrettyPrinter.swift
+++ b/Sources/BKBuildService/PrettyPrinter.swift
@@ -103,11 +103,14 @@ extension UInt64 {
         var x = self.bigEndian
         let data = Data(bytes: &x, count: MemoryLayout<UInt64>.size)
         let mapping = data.map{$0}
-        // This is only used when debugging input/output streams
-        // so force unwrapp here should be fine, if this raises for any reason
-        // is probably because someone should take a look at this logic and fix things anyway
+        // This is supposed to be used only when debugging input/output streams
+        // at the time of writing grabbing the last bit here was enough to compose sequences of bytes that can be encoded into `String`
         //
-        // Grabbing the significant value here only from a mapping tha looks like this: [0, 0, 0, 0, 0, 0, 0, 105]
-        return mapping.last!
+        // Grabbs the significant value here only from the mapping, which looks like this: [0, 0, 0, 0, 0, 0, 0, 105]
+        guard let last = mapping.last else {
+            print("warning: Failed to get last UInt8 from UInt64 mapping \(mapping)")
+            return 0
+        }
+        return last
     }
 }

--- a/Sources/BKBuildService/PrettyPrinter.swift
+++ b/Sources/BKBuildService/PrettyPrinter.swift
@@ -1,0 +1,113 @@
+import Foundation
+import XCBProtocol
+
+class PrettyPrinter {
+  static func prettyPrintRecursively(_ result: Array<XCBRawValue>) {
+      parseIterator(result).forEach{ print($0) }
+  }
+
+  // Attempts to convert data into human readable format
+  // This is not supposed to be a perfect mapping but just reasonable
+  // guesses on how one could convert each type into something readable
+  // and it's only supposed to be used during development to inspect
+  // input/output from MessagePack while running `debug_*` action from `Makefile`
+  static private func parseBasicTypes(_ rawValue: XCBRawValue) -> Any {
+        switch rawValue {
+        case let .uint(value):
+            return value.uint8
+        case let .array(value):
+            return "array(\(self.parseIterator(value)))"
+        case .extended(let type, let data):
+            return "extended(\(type), \(data.readableString))"
+        case let .map(value):
+            var dict: [String: Any] = [:]
+            for (k,v) in value {
+                dict["\(self.parseBasicTypes(k))"] = self.parseBasicTypes(v)
+            }
+            return "map(\(dict))"
+        case let .binary(value):
+            return "binary(\(value.readableString))"
+        default:
+            return String(describing: rawValue)
+        }
+    }
+
+    // Special treatment for `.uint` type:
+    //
+    // The `.uint` type from MessagePack will repeat many times in the stream,
+    // this func accumulates the bytes and only when that chunk is complete attempts
+    // to convert it to something readable and adds that to the result
+    static private func parseIterator(_ result: Array<XCBRawValue>) -> [Any] {
+        var iterator = result.makeIterator()
+        var accumulatedBytes: [UInt8] = []
+        var result: [Any] = []
+
+        while let next = iterator.next() {
+            let nextParsed = self.parseBasicTypes(next)
+            if let nextParsedAsBytes = nextParsed as? UInt8 {
+                accumulatedBytes.append(nextParsedAsBytes)
+            } else {
+                if accumulatedBytes.count > 0 {
+                    result.append("uint(\(accumulatedBytes.readableString)))")
+                    accumulatedBytes = []
+                }
+                result.append(nextParsed)
+            }
+        }
+
+        if accumulatedBytes.count > 0 {
+            result.append("uint(\(accumulatedBytes.readableString))")
+            accumulatedBytes = []
+        }
+
+        return result
+    }
+}
+
+extension Data {
+    var readableString: String {
+        if let bplist = self.bplist {
+            return "bplist(\(bplist))"
+        }
+        return self.bytes.readableString
+    }
+
+    private var bplist: String? {
+        return BPlistConverter(binaryData: self)?.convertToXML()
+    }
+
+    private var bytes: [UInt8] {
+        return [UInt8](self)
+    }
+}
+
+extension Array where Element == UInt8 {
+    var readableString: String {
+        guard let bytesAsString = self.utf8String ?? self.asciiString else {
+            fatalError("Failed to encode bytes")
+        }
+        return bytesAsString
+    }
+
+    private var utf8String: String? {
+        return String(bytes: self, encoding: .utf8)
+    }
+
+    private var asciiString: String? {
+        return String(bytes: self, encoding: .ascii)
+    }
+}
+
+extension UInt64 {
+    var uint8: UInt8 {
+        var x = self.bigEndian
+        let data = Data(bytes: &x, count: MemoryLayout<UInt64>.size)
+        let mapping = data.map{$0}
+        // This is only used when debugging input/output streams
+        // so force unwrapp here should be fine, if this raises for any reason
+        // is probably because someone should take a look at this logic and fix things anyway
+        //
+        // Grabbing the significant value here only from a mapping tha looks like this: [0, 0, 0, 0, 0, 0, 0, 105]
+        return mapping.last!
+    }
+}

--- a/Sources/BKBuildService/Service.swift
+++ b/Sources/BKBuildService/Service.swift
@@ -15,6 +15,7 @@ public typealias XCBMessageHandler = (XCBInputStream, Data, Any?) -> Void
 
 public class BKBuildService {
     let shouldDump: Bool
+    let shouldDumpHumanReadable: Bool
 
     // This needs to be serial in order to serialize the messages / prevent
     // crossing streams.
@@ -22,6 +23,7 @@ public class BKBuildService {
 
     public init() {
         self.shouldDump = CommandLine.arguments.contains("--dump")
+        self.shouldDumpHumanReadable = CommandLine.arguments.contains("--dump_h")
     }
 
     /// Starts a service on standard input
@@ -44,14 +46,16 @@ public class BKBuildService {
                 log("missing id")
             }
 
-            let resultItr = result.makeIterator()
             if self.shouldDump {
                 // Dumps out the protocol
                 // useful for debuging, code gen'ing protocol messages, and
                 // upgrading Xcode versions
                 result.forEach{ $0.prettyPrint() }
+            } else if self.shouldDumpHumanReadable {
+                // Same as above but dumps out the protocol in human readable format
+                PrettyPrinter.prettyPrintRecursively(result)
             } else {
-                messageHandler(resultItr, data, context)
+                messageHandler(result.makeIterator(), data, context)
             }
         }
         repeat {


### PR DESCRIPTION
* Run `make open_xcode` and open `iOSApp/iOSApp.xcodeproj`
* Do some actions to generate input / output data
* Close Xcode
* Now note that one can continue to inspect debug messages with raw values (same as before) with these commands
```sh
make debug_input_raw
make debug_output_raw
```
but now there are two new commands to alternatively print human readable data:
```sh
make debug_input_h
make debug_output_h
```

See one example of raw vs human readable formats from a small chunk taken from two `make debug_input_raw/h`:

* `make debug_input_raw`:
```sh
XCBRawValue.string("SET_SESSION_USER_INFO"),
 XCBRawValue.uint(18),
 XCBRawValue.uint(85),
 XCBRawValue.uint(123),
 XCBRawValue.uint(34),
 XCBRawValue.uint(98),
 XCBRawValue.uint(117),
 XCBRawValue.uint(105),
 XCBRawValue.uint(108),
 XCBRawValue.uint(100),
 XCBRawValue.uint(83),
 XCBRawValue.uint(121),
 XCBRawValue.uint(115),
 XCBRawValue.uint(116),
 XCBRawValue.uint(101),
 # ... continues for many lines
```
* `make debug_input_h` (readable!):
```sh
string(SET_SESSION_USER_INFO)
# human readable format here: JSON, file paths, etc.
# e.g.: 
uint(U{"buildSystemEnvironment":{"PATH":"/Applications/Xcode.app/Contents/Developer/usr/bin:/usr/local/bin:/usr/bin:/bin:)
bplist(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict/>\n</plist>\n))
# ... etc.
```