### PR TITLE
[DNM] Example of how to pass indexing info response messages with symlinked object file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,24 @@ test: build
 
 # Random development commands
 # Opens Xcode with the build service selected
+open_xcode_with_sk_logging: build
+	/usr/bin/env - TERM="$(TERM)"; \
+			SOURCEKIT_LOGGING=3 \
+	    export SHELL="$(SHELL)"; \
+	    export PATH="$(PATH)"; \
+	    export HOME="$(HOME)"; \
+	    export XCODE="$(XCODE)"; \
+	    export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
+			$(XCODE)/Contents/MacOS/Xcode &> /tmp/xcode_sourcekit.log
+
 open_xcode: build
 	/usr/bin/env - TERM="$(TERM)"; \
 	    export SHELL="$(SHELL)"; \
 	    export PATH="$(PATH)"; \
 	    export HOME="$(HOME)"; \
 	    export XCODE="$(XCODE)"; \
-			export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
-      $(XCODE)/Contents/MacOS/Xcode
+	    export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
+			$(XCODE)/Contents/MacOS/Xcode
 
 clean:
 	rm -rf /tmp/xcbuild.*

--- a/Sources/BKBuildService/BPlistConverter.swift
+++ b/Sources/BKBuildService/BPlistConverter.swift
@@ -1,28 +1,28 @@
 import Foundation
 
 // Credits to: https://gist.github.com/ngbaanh/7c437d99bea75161a59f5af25be99de4
-class BPlistConverter {
+public class BPlistConverter {
     struct PlistMimeType {
         static let xmlPlist    = "text/x-apple-plist+xml"
         static let binaryPlist = "application/x-apple-binary-plist"
     }
 
     //// Visible Stuffs ////////////////////////////////////////////////////////
-    convenience init?(binaryData: Data, quiet: Bool = true) {
+    public convenience init?(binaryData: Data, quiet: Bool = true) {
         self.init(binaryData, format: .binaryFormat_v1_0, quiet: quiet)
     }
 
-    convenience init?(xml: String, quiet: Bool = true) {
+    public convenience init?(xml: String, quiet: Bool = true) {
         guard let xmlData = xml.data(using: .utf8) else { return nil }
         self.init(xmlData, format: .xmlFormat_v1_0, quiet: quiet)
     }
 
-    func convertToXML() -> String? {
+    public func convertToXML() -> String? {
         guard let xmlData = convert(to: .xmlFormat_v1_0) else { return nil }
         return String.init(data: xmlData, encoding: .utf8)
     }
 
-    func convertToBinary() -> Data? {
+    public func convertToBinary() -> Data? {
         return convert(to: .binaryFormat_v1_0)
     }
 

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -80,6 +80,8 @@ extension XCBDecoder {
                     return try BuildStartRequest(input: minput)
                 } else if str == "INDEXING_INFO_REQUESTED" {
                     return try IndexingInfoRequested(input: minput)
+                } else if str == "BUILD_DESCRIPTION_TARGET_INFO" {
+                    return try BuildDescriptionTargetInfo(input: minput)
                 }
             default:
                 continue

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -91,6 +91,10 @@ public struct BuildStartRequest: XCBProtocolMessage {
     public init(input _: XCBInputStream) throws {}
 }
 
+public struct BuildDescriptionTargetInfo: XCBProtocolMessage {
+    public init(input _: XCBInputStream) throws {}
+}
+
 public struct IndexingInfoRequested: XCBProtocolMessage {
     public init(input _: XCBInputStream) throws {}
 }
@@ -358,3 +362,70 @@ public struct BuildOperationEndedResponse: XCBProtocolMessage {
         ]
     }
 }
+
+public struct IndexingInfoReceivedResponse: XCBProtocolMessage {
+    let targetID: String
+    let data: Data?
+
+    public init(targetID: String = "", data: Data? = nil) {
+        self.targetID = targetID
+        self.data = data
+    }
+
+    public func encode(_: XCBEncoder) throws -> XCBResponse {
+        var inputs = [XCBRawValue.string(self.targetID)]
+        if let data = self.data {
+            inputs += [XCBRawValue.binary(data)]
+        }
+
+        return [
+            XCBRawValue.uint(26),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(37),
+            XCBRawValue.uint(1),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.string("INDEXING_INFO_RECEIVED"),
+            XCBRawValue.array(inputs),
+        ]
+    }
+}
+
+public struct BuildTargetPreparedForIndex: XCBProtocolMessage {
+    let targetGUID: String
+
+    public init(targetGUID: String) {
+        self.targetGUID = targetGUID
+    }
+
+    public func encode(_: XCBEncoder) throws -> XCBResponse {
+        return [
+            XCBRawValue.uint(24),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(109),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.uint(0),
+            XCBRawValue.string("BUILD_TARGET_PREPARED_FOR_INDEX"),
+            XCBRawValue.array([
+                XCBRawValue.string(self.targetGUID),
+                XCBRawValue.array([
+                    XCBRawValue.double(677604523.7527775),
+                ]),
+            ]),
+        ]
+    }
+}
+


### PR DESCRIPTION
#### Experiment

Small experiment to illustrate how we could potentially symlink indexing related files to `bazel-out` in such a way that Xcode continues to work. To repro the state below checkout this branch and follow these steps:

1. Better to cleanup DD state before anything: `rm -fr ~/Library/Developer/Xcode/DerivedData`
2. Make sure indexing is enabled: `make enable_indexing`
3. Open `iOSApp/iOSApp.xcodeproj` and build the `CLI` target (on M1 make sure you selected the `(Rosetta)` scheme for this experiment)
4. You should be able to find an object file under DD (see `(1)` in the screenshot):
```sh
find ~/Library/Developer/Xcode/DerivedData -name '*main.o'
``` 
5. Move that file to a different place (see `(2)` in the screenshot), say `mv path/to/main.o ~/Desktop/.`
6. Now where that file was located a symlink pointing to where you moved the original object file (see `(3)` in the screenshot):
```sh
cd ~/Library/Developer/Xcode/DerivedData/iOSApp-frrxxdgefswljmaayjgcihttruuq/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/Objects-normal/x86_64

ln -s ~/Desktop/main.o main.o
```
7. Now launch Xcode with SourceKit logging:
```sh
make open_xcode_with_sk_logging
```
8. Tail the log file to see updates (see `(4)` in the screenshot):
```sh
tail -f /tmp/xcode_sourcekit.log | grep main.o
```
8. In Xcode without triggering a new build that would override the symlink above edit `iOSApp/CLI/main.m`, say change the value of that string or allocate a new var and not that SK does not enter any kind of weird state (saw crashes / infinite loops in the past while testing this) and that messages involving `main.o` continue to be interpreted the same way:
```sh
tail -f /tmp/xcode_sourcekit.log | grep main.o

    "/Users/thiago/Library/Developer/Xcode/DerivedData/iOSApp-frrxxdgefswljmaayjgcihttruuq/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/Objects-normal/x86_64/main.o",
    "/iOSApp.build/Debug/CLI.build/Objects-normal/x86_64/main.o",
```

![symlinked_obj_sk_log](https://user-images.githubusercontent.com/10197663/179309450-987b3a6f-5e7b-42ea-b783-9bcbfe74e370.png)

#### Thoughts

With that I'm still trying to find the right way to interpret these results:

1. Does that mean that indexing accepts symlink-ed inputs like this and in theory we could symlink all the way to the object files generated by Bazel?
2. Any chance this only works because we're hitting some sort of cache that is not really trying to go back to disk and find the file where the symlink is?
3. If you compare results in the SK log when using this experiment versus vanilla Xcode in vanilla mode you'll see more instances of messages referencing `main.o` than the ones generated in this experiment. Meaning even with that we're probably not passing all messages yet (although apparently is enough for Xcode to do its thing and not crash).

