### PR TITLE
Fix make debug cmds not working because Xcode was not found yet

### DIFF
--- a/Sources/BKBuildService/XCBBuildServiceProcess.swift
+++ b/Sources/BKBuildService/XCBBuildServiceProcess.swift
@@ -56,14 +56,14 @@ public class XCBBuildServiceProcess {
     /// the request.
     ///
     /// This isn't safe and should be called seraially during a response handler
-    public func write(_ data: Data) {
+    public func write(_ data: Data, xcode: String? = nil) {
         if self.process.isRunning == false {
             // This has happened when attempting to build _swift_ toolchain from
             // source.
             //
             // If the binary was copied into Xcode than start using that.
             log("warning: attempted to message XCBBuildService before starting it")
-            startIfNecessary(xcode: nil)
+            startIfNecessary(xcode: xcode)
         }
         // writes aren't serial here ( rational it already is via stdin )
         self.stdin.fileHandleForWriting.write(data)


### PR DESCRIPTION
Added a comment with reasoning here, we'll come back to fix this later once foundational work is done and we're ready to make installing the macOS package works correctly (placing the `.default` binary where it should be).

```
// TODO: Remove and handle this once we're able to install `.default` build service correctly
// Without this early return it will try to `startIfNecessary` before finding an Xcode and raise an exception because `.default` build service is not installed.
// See: `Sources/BKBuildService/XCBBuildServiceProcess.swift`
//
// This was causing `make debug_*` commands to fail on master
```

The error I get without these changes when running `make debug_*` cmds, e.g., `make debug_output_raw`:
```sh
BKBuildService/XCBBuildServiceProcess.swift:83: Fatal error: XCBBuildServiceProcess - unexpected installation.  /tmp/bazel_temp.JqgJCv/XCBBuildServiceProxy.app/Contents/MacOS/XCBBuildServiceProxy.default
/private/var/tmp/_bazel_thiago/8a4307177d5b14fb5cab5b967892743d/execroot/__main__/bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-73b41d209e9d/bin/XCBBuildServiceProxy: line 42:   194 Illegal instruction: 4  "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"
make: *** [debug_output_raw] Error 132 
```
