### PR TITLE
minor dx improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bazel-*
 .xcode_select_env
 external
 *.app
+iOSApp/build
+iOSApp/iOSApp.xcodeproj/project.xcworkspace/xcshareddata

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ open_xcode: build
 	    export PATH="$(PATH)"; \
 	    export HOME="$(HOME)"; \
 	    export XCODE="$(XCODE)"; \
-      export DEBUG_BUILDSERVICE_PATH="$(BUILD_SERVICE_PATH)"; \
+	    export DEBUG_BUILDSERVICE_PATH="$(BUILD_SERVICE_PATH)"; \
 	    export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
 			$(XCODE)/Contents/MacOS/Xcode
 

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ open_xcode: build
 	    export PATH="$(PATH)"; \
 	    export HOME="$(HOME)"; \
 	    export XCODE="$(XCODE)"; \
+      export DEBUG_BUILDSERVICE_PATH="$(BUILD_SERVICE_PATH)"; \
 	    export XCBBUILDSERVICE_PATH="$(XCBBUILDSERVICE_PATH)"; \
 			$(XCODE)/Contents/MacOS/Xcode
 
@@ -108,6 +109,12 @@ disable_indexing:
 # Note: the static build service doesn't work with this ATM
 enable_indexing:
 	defaults write com.apple.dt.XCode IDEIndexDisable 0
+
+enable_indexing_logs:
+	defaults write com.apple.dt.Xcode IDEIndexShowLog 1
+
+disable_indexing_logs:
+	defaults write com.apple.dt.Xcode IDEIndexShowLog 0
 
 # Uses xxd to inspect outputs
 hex_dump: FILE_A=/tmp/xcbuild.in

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -93,8 +93,8 @@ extension XCBDecoder {
     }
 }
 
-public func log(_ str: String) {
-    let url = URL(fileURLWithPath: "/tmp/xcbuild.log")
+public func log(_ str: String, logPath: String = "/tmp/xcbuild.log") {
+    let url = URL(fileURLWithPath: logPath)
     let entry = str + "\n"
     do {
         let fileUpdater = try FileHandle(forWritingTo: url)

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -93,8 +93,8 @@ extension XCBDecoder {
     }
 }
 
-public func log(_ str: String, logPath: String = "/tmp/xcbuild.log") {
-    let url = URL(fileURLWithPath: logPath)
+public func log(_ str: String) {
+    let url = URL(fileURLWithPath: "/tmp/xcbuild.log")
     let entry = str + "\n"
     do {
         let fileUpdater = try FileHandle(forWritingTo: url)


### PR DESCRIPTION
* Add to `.gitignore` some files that are generated when running make commands and that we don't want to commit
* Add new make commands to turn indexing logs on/off in Xcode
* Minor refactor to `log` function so one can specify a different log file in the call site during development
* Fix missing `DEBUG_BUILDSERVICE_PATH` in one make command