### PR TITLE
Add test case for indexing with custom index store

### DIFF
--- a/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
+++ b/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
@@ -113,7 +113,7 @@ let clangXMLT: String = """
                         <string>-DXCBTEST=1</string>
                         <string>-DOBJC_OLD_DISPATCH_PROTOTYPES=0</string>
                         <string>-isysroot</string>
-                        <string>__MACOS_SDK__</string>
+                        <string>__SDK_PATH__</string>
                         <string>-fasm-blocks</string>
                         <string>-fstrict-aliasing</string>
                         <string>-Wprotocol</string>
@@ -175,14 +175,15 @@ public enum XCBBuildServiceProxyStub {
                                       outputFilePath: String,
                                       derivedDataPath: String,
                                       workspaceHash: String,
-                                      macOSSDK: String,
+                                      workspaceName: String,
+                                      sdkPath: String,
                                       workingDir: String) -> Data {
                 let clangXML = clangXMLT.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
                 .replacingOccurrences(of:"__OUTPUT_FILE_PATH__", with: outputFilePath)
-                .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/iOSApp-\(workspaceHash)/Index/DataStore")
+                .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/\(workspaceName)-\(workspaceHash)/Index/DataStore")
                 .replacingOccurrences(of:"__DERIVED_DATA_PATH__", with: derivedDataPath)
                 .replacingOccurrences(of:"__WORSPACE_HASH__", with: workspaceHash)
-                .replacingOccurrences(of:"__MACOS_SDK__", with: macOSSDK)
+                .replacingOccurrences(of:"__SDK_PATH__", with: sdkPath)
                 .replacingOccurrences(of:"__WORKING_DIR__", with: workingDir)
 
                 return BPlistConverter(xml: clangXML)?.convertToBinary() ?? Data()

--- a/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
+++ b/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
@@ -45,7 +45,7 @@ let clangXMLT: String = """
                 <key>LanguageDialect</key>
                 <string>objective-c</string>
                 <key>clangASTBuiltProductsDir</key>
-                <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Products/Debug</string>
+                <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug</string>
                 <key>clangASTCommandArguments</key>
                 <array>
                         <string>-x</string>
@@ -59,7 +59,7 @@ let clangXMLT: String = """
                         <string>-fobjc-arc</string>
                         <string>-fobjc-weak</string>
                         <string>-fmodules</string>
-                        <string>-fmodules-cache-path=/Users/jmarino/Library/Developer/Xcode/DerivedData/ModuleCache.noindex</string>
+                        <string>-fmodules-cache-path=__DERIVED_DATA_PATH__/ModuleCache.noindex</string>
                         <string>-fmodules-prune-interval=86400</string>
                         <string>-fmodules-prune-after=345600</string>
                         <string>-Wnon-modular-include-in-framework-module</string>
@@ -110,10 +110,10 @@ let clangXMLT: String = """
                         <string>-Wundeclared-selector</string>
                         <string>-Wdeprecated-implementations</string>
                         <string>-DDEBUG=1</string>
-                        <string>-DDEMOSQUARE=1</string>
+                        <string>-DXCBTEST=1</string>
                         <string>-DOBJC_OLD_DISPATCH_PROTOTYPES=0</string>
                         <string>-isysroot</string>
-                        <string>/Applications/Xcode-13.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk</string>
+                        <string>__MACOS_SDK__</string>
                         <string>-fasm-blocks</string>
                         <string>-fstrict-aliasing</string>
                         <string>-Wprotocol</string>
@@ -127,39 +127,39 @@ let clangXMLT: String = """
                         <string>-Wno-semicolon-before-method-body</string>
                         <string>-Wunguarded-availability</string>
                         <string>-index-store-path</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/DataStore</string>
+                        <string>__INDEX_STORE_PATH__</string>
                         <string>-iquote</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-generated-files.hmap</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-own-target-headers.hmap</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-all-target-headers.hmap</string>
+                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-generated-files.hmap</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-own-target-headers.hmap</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-all-target-headers.hmap</string>
                         <string>-iquote</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-project-headers.hmap</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Products/Debug/include</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources-normal/x86_64</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources/x86_64</string>
-                        <string>-I/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources</string>
-                        <string>-F/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Products/Debug</string>
+                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-project-headers.hmap</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug/include</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources-normal/x86_64</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources/x86_64</string>
+                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources</string>
+                        <string>-F__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug</string>
                         <string>-fsyntax-only</string>
-                        <string>/Users/jmarino/Development/xcbuildkit/iOSApp/CLI/main.m</string>
+                        <string>__SOURCE_FILE__</string>
                         <string>-o</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/Objects-normal/x86_64/main.o</string>
+                        <string>__OUTPUT_FILE_PATH__</string>
                         <string>-Xclang</string>
                         <string>-fallow-pcm-with-compiler-errors</string>
                         <string>-ivfsoverlay</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/regular-to-index-overlay.yaml</string>
+                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/regular-to-index-overlay.yaml</string>
                         <string>-ivfsoverlay</string>
-                        <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/index-to-regular-overlay.yaml</string>
+                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/index-to-regular-overlay.yaml</string>
                         <string>-fretain-comments-from-system-headers</string>
                         <string>-ferror-limit=10</string>
-                        <string>-working-directory=/Users/jmarino/Development/xcbuildkit/iOSApp</string>
+                        <string>-working-directory=__WORKING_DIR__</string>
                         <string>-Xclang</string>
                         <string>-detailed-preprocessing-record</string>
                         <string>-DZZ=1</string>
                 </array>
                 <key>outputFilePath</key>
-                <string>/Users/jmarino/Library/Developer/Xcode/DerivedData/iOSApp-fwoljlvejnobrkfexfutlxhtoaow/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/Objects-normal/x86_64/main.o</string>
+                <string>__OUTPUT_FILE_PATH__</string>
                 <key>sourceFilePath</key>
-                <string>/Users/jmarino/Development/xcbuildkit/iOSApp/CLI/main.m</string>
+                <string>__SOURCE_FILE__</string>
                 <key>toolchains</key>
                 <array>
                         <string>com.apple.dt.toolchain.XcodeDefault</string>
@@ -170,9 +170,22 @@ let clangXMLT: String = """
 """
 
 public enum XCBBuildServiceProxyStub {
-   public static func getASTArgs(targetID: String, outputFilePath: String) -> Data {
-       let clangXML = clangXMLT.replacingOccurrences(of:"__SOURCE_FILE__", with: outputFilePath)
-       return BPlistConverter(xml: clangXML)?.convertToBinary() ?? Data()
-   }
+        public static func getASTArgs(targetID: String,
+                                      sourceFilePath: String,
+                                      outputFilePath: String,
+                                      derivedDataPath: String,
+                                      workspaceHash: String,
+                                      macOSSDK: String,
+                                      workingDir: String) -> Data {
+                let clangXML = clangXMLT.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
+                .replacingOccurrences(of:"__OUTPUT_FILE_PATH__", with: outputFilePath)
+                .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/iOSApp-\(workspaceHash)/Index/DataStore")
+                .replacingOccurrences(of:"__DERIVED_DATA_PATH__", with: derivedDataPath)
+                .replacingOccurrences(of:"__WORSPACE_HASH__", with: workspaceHash)
+                .replacingOccurrences(of:"__MACOS_SDK__", with: macOSSDK)
+                .replacingOccurrences(of:"__WORKING_DIR__", with: workingDir)
+
+                return BPlistConverter(xml: clangXML)?.convertToBinary() ?? Data()
+        }
 }
 

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -40,6 +40,8 @@ let writeQueue = DispatchQueue(label: "com.xcbuildkit.bkbuildservice-bzl")
 private var gChunkNumber = 0
 // FIXME: get this from the other paths
 private var gXcode = ""
+// TODO: parsed in `CreateSessionRequest`, consider a more stable approach instead of parsing `xcbuildDataPath` path there
+private var workspaceHash = ""
 
 // TODO: Make this part of an API to be consumed from callers
 //
@@ -50,17 +52,6 @@ private let outputFileForSource: [String: String] = [
     // `echo $PWD/iOSApp/CLI/main.m`
     "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/CLI/main.m": "/tmp/xcbuild-out/main.o"
 ]
-
-// TODO: parse from input stream or Xcode env
-//
-// Example: `/path/to/DerivedData/iOSApp-frhmkkebaragakhdzyysbrsvbgtc`
-//
-// Read more about this identifier here:
-// https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html
-//
-// Should match value in `Makefile > generate_custom_index_store`
-//
-let workspaceHash = "frhmkkebaragakhdzyysbrsvbgtc"
 
 // TODO: parse this from somewhere
 // To generate on the cmd line run
@@ -130,6 +121,7 @@ enum BasicMessageHandler {
         if let msg = decoder.decodeMessage() {
             if let createSessionRequest = msg as? CreateSessionRequest {
                 gXcode = createSessionRequest.xcode
+                workspaceHash = createSessionRequest.workspaceHash
                 xcbbuildService.startIfNecessary(xcode: gXcode)
             } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && msg is IndexingInfoRequested {
                 // Example of a custom indexing service

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -41,11 +41,76 @@ private var gChunkNumber = 0
 // FIXME: get this from the other paths
 private var gXcode = ""
 
+// TODO: Make this part of an API to be consumed from callers
+//
+// "source file" => "output file" map, hardcoded for now, will be part of the API in the future
+// Should match your local path and the values set in `Makefile > generate_custom_index_store`
+//
+private let outputFileForSource: [String: String] = [
+    // `echo $PWD/iOSApp/CLI/main.m`
+    "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/CLI/main.m": "/tmp/xcbuild-out/main.o"
+]
+
+// TODO: parse from input stream or Xcode env
+//
+// Example: `/path/to/DerivedData/iOSApp-frhmkkebaragakhdzyysbrsvbgtc`
+//
+// Read more about this identifier here:
+// https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html
+//
+// Should match value in `Makefile > generate_custom_index_store`
+//
+let workspaceHash = "frhmkkebaragakhdzyysbrsvbgtc"
+
+// TODO: parse this from somewhere
+// To generate on the cmd line run
+//
+// xcrun --sdk macosx --show-sdk-path
+//
+// Should match value in `Makefile > generate_custom_index_store`
+//
+let macOSSDK = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk"
+
+// TODO: `pwd` this and pass on the cmd line or parse from input stream (?)
+//
+// Effectively the result of running this from this repo root:
+//
+// `echo $PWD/iOSApp`
+//
+// Should match value in `Makefile > generate_custom_index_store`
+//
+let workingDir = "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp"
+
 /// This example listens to a BEP stream to display some output.
 ///
 /// All operations are delegated to XCBBuildService and we inject
 /// progress from BEP.
 enum BasicMessageHandler {
+    // Required if `outputPathOnly` is `true` in the indexing request
+    static func outputPathOnlyData(outputFilePath: String, sourceFilePath: String) -> Data {
+        let xml = """
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+            <array>
+                <dict>
+                    <key>outputFilePath</key>
+                    <string>\(outputFilePath)</string>
+                    <key>sourceFilePath</key>
+                    <string>\(sourceFilePath)</string>
+                </dict>
+            </array>
+        </plist>
+        """
+        guard let converter = BPlistConverter(xml: xml) else {
+            fatalError("Failed to allocate converter")
+        }
+        guard let bplistData = converter.convertToBinary() else {
+            fatalError("Failed to convert XML to binary plist data")
+        }
+
+        return bplistData
+    }
+
     /// Proxying response handler
     /// Every message is written to the XCBBuildService
     /// This simply injects Progress messages from the BEP
@@ -62,10 +127,24 @@ enum BasicMessageHandler {
             } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && msg is IndexingInfoRequested {
                 // Example of a custom indexing service
                 let reqMsg = msg as! IndexingInfoRequested
-                let clangXMLData = XCBBuildServiceProxyStub.getASTArgs(targetID: reqMsg.targetID, outputFilePath: reqMsg.filePath)
+                guard let outputFilePath = outputFileForSource[reqMsg.filePath] else {
+                    fatalError("Failed to find output file for source: \(reqMsg.filePath)")
+                    return
+                }
+
+                log("Found output file \(outputFilePath) for source \(reqMsg.filePath)")
+
+                let clangXMLData = XCBBuildServiceProxyStub.getASTArgs(
+                    targetID: reqMsg.targetID,
+                    sourceFilePath: reqMsg.filePath,
+                    outputFilePath: outputFilePath,
+                    derivedDataPath: reqMsg.derivedDataPath,
+                    workspaceHash: workspaceHash,
+                    macOSSDK: macOSSDK,
+                    workingDir: workingDir)
                 let message = IndexingInfoReceivedResponse(
                     targetID: reqMsg.targetID,
-                    data: reqMsg.outputPathOnly ? Data() : nil,
+                    data: reqMsg.outputPathOnly ? outputPathOnlyData(outputFilePath: outputFilePath, sourceFilePath: reqMsg.filePath) : nil,
                     responseChannel: UInt64(reqMsg.responseChannel),
                     clangXMLData: reqMsg.outputPathOnly ? nil : clangXMLData)
                 if let encoded: XCBResponse = try? message.encode(encoder) {

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -69,7 +69,14 @@ let workspaceHash = "frhmkkebaragakhdzyysbrsvbgtc"
 //
 // Should match value in `Makefile > generate_custom_index_store`
 //
-let macOSSDK = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk"
+// ps: note that globals are lazy by default
+var macOSSDK: String {
+    guard gXcode.count > 0 else {
+        fatalError("Failed to build macOS SDK path, Xcode path is empty: \(gXcode)")
+    }
+
+    return "\(gXcode)/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk"
+}
 
 // TODO: `pwd` this and pass on the cmd line or parse from input stream (?)
 //
@@ -123,7 +130,7 @@ enum BasicMessageHandler {
         if let msg = decoder.decodeMessage() {
             if let createSessionRequest = msg as? CreateSessionRequest {
                 gXcode = createSessionRequest.xcode
-                xcbbuildService.startIfNecessary(xcode: createSessionRequest.xcode)
+                xcbbuildService.startIfNecessary(xcode: gXcode)
             } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && msg is IndexingInfoRequested {
                 // Example of a custom indexing service
                 let reqMsg = msg as! IndexingInfoRequested

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -50,18 +50,11 @@ private var gChunkNumber = 0
 // FIXME: get this from the other paths
 private var gXcode = ""
 // TODO: parsed in `CreateSessionRequest`, consider a more stable approach instead of parsing `xcbuildDataPath` path there
-// Should match value in `Makefile > generate_custom_index_store`
 private var workspaceHash = ""
 // TODO: parsed in `IndexingInfoRequested`, there's probably a less hacky way to get this.
 // Effectively `$PWD/iOSApp`
-// Should match value in `Makefile > generate_custom_index_store`
 private var workingDir = ""
-// TODO: parse this from somewhere
-// To generate on the cmd line run
-//
-// xcrun --sdk macosx --show-sdk-path
-//
-// Should match value in `Makefile > generate_custom_index_store`
+// TODO: parse the relative path to the SDK from somewhere
 var macOSSDK: String {
     guard gXcode.count > 0 else {
         fatalError("Failed to build macOS SDK path, Xcode path is empty: \(gXcode)")
@@ -117,13 +110,12 @@ enum BasicMessageHandler {
             } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && msg is IndexingInfoRequested {
                 // Example of a custom indexing service
                 let reqMsg = msg as! IndexingInfoRequested
+                workingDir = reqMsg.workingDir
+
                 guard let outputFilePath = outputFileForSource[reqMsg.filePath] else {
                     fatalError("Failed to find output file for source: \(reqMsg.filePath)")
                     return
                 }
-
-                workingDir = reqMsg.workingDir
-
                 log("Found output file \(outputFilePath) for source \(reqMsg.filePath)")
 
                 let clangXMLData = XCBBuildServiceProxyStub.getASTArgs(

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ open_xcode: build
 			$(XCODE)/Contents/MacOS/Xcode
 
 clean:
-	rm -rf /tmp/xcbuild.*
+	rm -fr /tmp/xcbuild.* && \
+	rm -fr /tmp/xcbuild-*
 
 symlink_external:
 	ln -sf $(shell tools/bazelwrapper info execution_root)/external external
@@ -150,3 +151,20 @@ debug_input_h:
 debug_output_python: build
 	@cat /tmp/xcbuild.out | utils/msgpack_dumper.py
 
+# For more details about the usage of these see TODOs in `Examples/XCBBuildServiceProxy/main.swift`
+#
+MACOS_SDK=$(shell xcrun --sdk macosx --show-sdk-path) # /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
+CLANG=$(shell xcrun --find clang) # /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+WORKSPACE_HASH=frhmkkebaragakhdzyysbrsvbgtc
+TMP_DD=/tmp/xcbuild-dd
+TMP_INDEX_STORE=${TMP_DD}/iOSApp-${WORKSPACE_HASH}/Index/DataStore
+TMP_OUT=/tmp/xcbuild-out
+
+make generate_custom_index_store:
+	mkdir -p ${TMP_DD} && \
+	mkdir -p ${TMP_OUT} && \
+	${CLANG} \
+	-isysroot ${MACOS_SDK} \
+	-c ${PWD}/iOSApp/CLI/main.m \
+	-o ${TMP_OUT}/main.o \
+	-index-store-path ${TMP_INDEX_STORE}

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ open_xcode: build
 			$(XCODE)/Contents/MacOS/Xcode
 
 clean:
-	rm -fr /tmp/xcbuild.* && \
-	rm -fr /tmp/xcbuild-*
+	rm -fr /tmp/xcbuild{.,-}*
 
 symlink_external:
 	ln -sf $(shell tools/bazelwrapper info execution_root)/external external

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -202,7 +202,6 @@ public struct IndexingInfoRequested: XCBProtocolMessage {
         self.filePath = json["filePath"] as? String ?? "<garbage>"
         self.outputPathOnly = json["outputPathOnly"] as? Bool ?? false
 
-        // FIXME: Disable / unused - for now
         let requestJSON = json["request"] as? [String: Any] ?? [:]
 
          let jsonRep64Str = requestJSON["jsonRepresentation"] as? String ?? ""

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -63,6 +63,7 @@ private extension XCBEncoder {
 
 public struct CreateSessionRequest: XCBProtocolMessage {
     public let workspace: String
+    public let workspaceHash: String
     public let xcode: String
     public let xcbuildDataPath: String
 
@@ -93,6 +94,9 @@ public struct CreateSessionRequest: XCBProtocolMessage {
         } else {
             self.xcbuildDataPath = ""
         }
+
+        // TODO: This is hacky, just an initial approach for better DX for now. Find a better way.
+        self.workspaceHash = self.xcbuildDataPath.components(separatedBy: "-").last!.replacingOccurrences(of: "/Build/Intermediates.noindex/XCBuildData", with: "")
     }
 }
 


### PR DESCRIPTION
#### Summary

* Make `clang` plist a bit more generic
* Pass correct `bplist` if `outputPathOnly` is `true`
* Parse `derivedDataPath` from input stream
* Add test case for indexing with custom index store/output file locations (via `generate_custom_index_store`)
* `clean` action now cleans `xcbuild-*` directories

#### Testing

This allows one to generate a custom index store and make Xcode read/write to it. See steps to see it working below.

**Note**: Every time I say "check `SKAgent` logs" I mean the system logs for that process, one can use the `Console.app` and filter by `com.apple.dt.SKAgent` (filter by `Process` is less verbose than by `Any`) or run this command while stepping through the items above (no errors should should up at all times):
```sh
log show --process com.apple.dt.SKAgent --info --debug --last 10m
```

1. Make sure your Xcode's DerivedData path is set to the value in the `Makefile` under `generate_custom_index_store`, i.e., `/tmp/xcbuild-dd`. Also make sure indexing is enabled `make enable_indexing`. Also make sure all hard coded values are set correctly for your local development paths in `Examples/XCBBuildServiceProxy/main.swift`, specifically these variables: `workspaceHash`, `macOSSDK` and `workingDir`.
2. Run `make clean` to make sure you're starting from a clean state
3. Run `make generate_custom_index_store` to generate the output file under `/tmp/xcbuild-out` and the index store under `/tmp/xcbuild-dd`
4. Check last time the unit/record files for the `main.m` source were accessed:
```sh
ls -lahuT /tmp/xcbuild-dd/**/*main.(m|o)*

Aug 15 12:00:03 2022 /tmp/xcbuild-dd/iOSApp-frhmkkebaragakhdzyysbrsvbgtc/Index/DataStore/v5/records/M2/main.m-L3EF644W13M2
Aug 15 12:00:03 2022 /tmp/xcbuild-dd/iOSApp-frhmkkebaragakhdzyysbrsvbgtc/Index/DataStore/v5/units/main.o-3BKBTVHON7PF1
```
5. Now using another terminal open Xcode with SourceKit logs enabled `make open_xcode_with_sk_logging`
6. Check the output and also the system `SKAgent` logs, no errors should be shown
7. Open `CLI/main.m` if it's not opened already and save the file. Note how the unit/record files "last accessed" dates change (you'll see that without making changes to the source only the unit file is accessed).
8. Now add a new line in `CLI/main.m` and not how a new record file is created (you can use the same `ls` command above while testing this).

Effectively what is happening here is that (1) Xcode took the unit/record files we generated manually in step `.3` without trying to override it or generate ones with different checksums and (2) the index store is located under a different root than the output file `main.o` (i.e. `/tmp/xcbuild-dd` and `/tmp/xcbuild-out`) meaning that as long as the indexing messages and passed correctly Xcode accepts that. This opens the possibility of handling compilation and index store generation separately using other build systems.

