### PR TITLE
Complete buffering logic

### DIFF
--- a/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
+++ b/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
@@ -45,7 +45,7 @@ let clangXMLT: String = """
                 <key>LanguageDialect</key>
                 <string>objective-c</string>
                 <key>clangASTBuiltProductsDir</key>
-                <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug</string>
+                <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORSPACE_HASH__/Index/Build/Products/Debug-iphonesimulator</string>
                 <key>clangASTCommandArguments</key>
                 <array>
                         <string>-x</string>
@@ -128,27 +128,12 @@ let clangXMLT: String = """
                         <string>-Wunguarded-availability</string>
                         <string>-index-store-path</string>
                         <string>__INDEX_STORE_PATH__</string>
-                        <string>-iquote</string>
-                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-generated-files.hmap</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-own-target-headers.hmap</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-all-target-headers.hmap</string>
-                        <string>-iquote</string>
-                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/CLI-project-headers.hmap</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug/include</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources-normal/x86_64</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources/x86_64</string>
-                        <string>-I__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/iOSApp.build/Debug/CLI.build/DerivedSources</string>
-                        <string>-F__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Products/Debug</string>
                         <string>-fsyntax-only</string>
                         <string>__SOURCE_FILE__</string>
                         <string>-o</string>
                         <string>__OUTPUT_FILE_PATH__</string>
                         <string>-Xclang</string>
                         <string>-fallow-pcm-with-compiler-errors</string>
-                        <string>-ivfsoverlay</string>
-                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/regular-to-index-overlay.yaml</string>
-                        <string>-ivfsoverlay</string>
-                        <string>__DERIVED_DATA_PATH__/iOSApp-__WORSPACE_HASH__/Index/Build/Intermediates.noindex/index-to-regular-overlay.yaml</string>
                         <string>-fretain-comments-from-system-headers</string>
                         <string>-ferror-limit=10</string>
                         <string>-working-directory=__WORKING_DIR__</string>
@@ -177,13 +162,16 @@ public enum XCBBuildServiceProxyStub {
                                       workspaceHash: String,
                                       workspaceName: String,
                                       sdkPath: String,
+                                      sdkName: String,
                                       workingDir: String) -> Data {
                 let clangXML = clangXMLT.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
                 .replacingOccurrences(of:"__OUTPUT_FILE_PATH__", with: outputFilePath)
                 .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/\(workspaceName)-\(workspaceHash)/Index/DataStore")
+                .replacingOccurrences(of:"__WORKSPACE_NAME__", with: workspaceName)
                 .replacingOccurrences(of:"__DERIVED_DATA_PATH__", with: derivedDataPath)
                 .replacingOccurrences(of:"__WORSPACE_HASH__", with: workspaceHash)
                 .replacingOccurrences(of:"__SDK_PATH__", with: sdkPath)
+                .replacingOccurrences(of:"__SDK_NAME__", with: sdkName)
                 .replacingOccurrences(of:"__WORKING_DIR__", with: workingDir)
 
                 return BPlistConverter(xml: clangXML)?.convertToBinary() ?? Data()

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -41,9 +41,11 @@ let writeQueue = DispatchQueue(label: "com.xcbuildkit.bkbuildservice-bzl")
 //
 // "source file" => "output file" map, hardcoded for now, will be part of the API in the future
 // Should match your local path and the values set in `Makefile > generate_custom_index_store`
-private let outputFileForSource: [String: String] = [
-    "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/CLI/main.m": "/tmp/xcbuild-out/CLI/main.o",
-    "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/iOSApp/main.m": "/tmp/xcbuild-out/iOSApp/main.o",
+private let outputFileForSource: [String: [String: String]] = [
+    "iOSApp-frhmkkebaragakhdzyysbrsvbgtc": [
+        "/CLI/main.m": "/tmp/xcbuild-out/CLI/main.o",
+        "/iOSApp/main.m": "/tmp/xcbuild-out/iOSApp/main.o",
+    ],
 
     // TODO: Should come from an aspect in Bazel
     // Examples of what Bazel mappings would look like
@@ -51,14 +53,6 @@ private let outputFileForSource: [String: String] = [
     // "Test-XCBuildKit/Users/thiago/Development/rules_ios/tests/ios/app/App/main.m": "bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-0f1b0425081f/bin/tests/ios/app/_objs/App_objc/arc/main.o",
     // "Test-XCBuildKit/Users/thiago/Development/rules_ios/tests/ios/app/App/Foo.m": "bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-0f1b0425081f/bin/tests/ios/app/_objs/App_objc/arc/Foo.o",
 ]
-
-// TODO: In Bazel land shoud come from an aspect of from the BEP
-// For now, `nil` simply means to allow the service to parse fron the input stream in vanilla Xcode
-// Example of what the bazel path would look like:
-//
-// private let externalWorkingDir: String = "/private/var/tmp/_bazel_thiago/122885c1fe4a2c6ed7635584956dfc9d/execroot/build_bazel_rules_ios"
-//
-let externalWorkingDir: String? = nil
 
 private var gChunkNumber = 0
 // FIXME: get this from the other paths
@@ -141,7 +135,9 @@ enum BasicMessageHandler {
                 platform = reqMsg.platform
                 sdk = reqMsg.sdk
 
-                guard let outputFilePath = outputFileForSource[reqMsg.filePath] else {
+                let workspaceKey = "\(workspaceName)-\(workspaceHash)"
+                let sourceKey = reqMsg.filePath.replacingOccurrences(of: workingDir, with: "")
+                guard let outputFilePath = outputFileForSource[workspaceKey]?[sourceKey] else {
                     fatalError("Failed to find output file for source: \(reqMsg.filePath)")
                     return
                 }
@@ -185,7 +181,7 @@ enum BasicMessageHandler {
 }
 
 let xcbbuildService = XCBBuildServiceProcess()
-let bkservice = BKBuildService(indexingEnabled: true, workingDir: externalWorkingDir)
+let bkservice = BKBuildService(indexingEnabled: true)
 
 let context = BasicMessageContext(
     xcbbuildService: xcbbuildService,

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -42,8 +42,23 @@ let writeQueue = DispatchQueue(label: "com.xcbuildkit.bkbuildservice-bzl")
 // "source file" => "output file" map, hardcoded for now, will be part of the API in the future
 // Should match your local path and the values set in `Makefile > generate_custom_index_store`
 private let outputFileForSource: [String: String] = [
-    "iOSApp/CLI/main.m": "/tmp/xcbuild-out/main.o"
+    "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/CLI/main.m": "/tmp/xcbuild-out/CLI/main.o",
+    "/Users/thiago/Development/thiagohmcruz/xcbuildkit/iOSApp/iOSApp/main.m": "/tmp/xcbuild-out/iOSApp/main.o",
+
+    // TODO: Should come from an aspect in Bazel
+    // Examples of what Bazel mappings would look like
+    //
+    // "Test-XCBuildKit/Users/thiago/Development/rules_ios/tests/ios/app/App/main.m": "bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-0f1b0425081f/bin/tests/ios/app/_objs/App_objc/arc/main.o",
+    // "Test-XCBuildKit/Users/thiago/Development/rules_ios/tests/ios/app/App/Foo.m": "bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-0f1b0425081f/bin/tests/ios/app/_objs/App_objc/arc/Foo.o",
 ]
+
+// TODO: In Bazel land shoud come from an aspect of from the BEP
+// For now, `nil` simply means to allow the service to parse fron the input stream in vanilla Xcode
+// Example of what the bazel path would look like:
+//
+// private let externalWorkingDir: String = "/private/var/tmp/_bazel_thiago/122885c1fe4a2c6ed7635584956dfc9d/execroot/build_bazel_rules_ios"
+//
+let externalWorkingDir: String? = nil
 
 private var gChunkNumber = 0
 // FIXME: get this from the other paths
@@ -126,8 +141,7 @@ enum BasicMessageHandler {
                 platform = reqMsg.platform
                 sdk = reqMsg.sdk
 
-                let outputFileKey = "\(workspaceName)\(reqMsg.filePath.replacingOccurrences(of: workingDir, with: ""))"
-                guard let outputFilePath = outputFileForSource[outputFileKey] else {
+                guard let outputFilePath = outputFileForSource[reqMsg.filePath] else {
                     fatalError("Failed to find output file for source: \(reqMsg.filePath)")
                     return
                 }
@@ -141,6 +155,7 @@ enum BasicMessageHandler {
                     workspaceHash: workspaceHash,
                     workspaceName: workspaceName,
                     sdkPath: sdkPath,
+                    sdkName: sdk,
                     workingDir: workingDir)
 
                 let message = IndexingInfoReceivedResponse(
@@ -170,7 +185,7 @@ enum BasicMessageHandler {
 }
 
 let xcbbuildService = XCBBuildServiceProcess()
-let bkservice = BKBuildService(indexingEnabled: true)
+let bkservice = BKBuildService(indexingEnabled: true, workingDir: externalWorkingDir)
 
 let context = BasicMessageContext(
     xcbbuildService: xcbbuildService,

--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,15 @@ TMP_OUT=/tmp/xcbuild-out
 
 make generate_custom_index_store:
 	mkdir -p ${TMP_DD} && \
-	mkdir -p ${TMP_OUT} && \
+	mkdir -p ${TMP_OUT}/CLI && \
+	mkdir -p ${TMP_OUT}/iOSApp && \
 	${CLANG} \
 	-isysroot ${MACOS_SDK} \
 	-c ${PWD}/iOSApp/CLI/main.m \
-	-o ${TMP_OUT}/main.o \
+	-o ${TMP_OUT}/CLI/main.o \
+	-index-store-path ${TMP_INDEX_STORE} && \
+	${CLANG} \
+	-isysroot ${MACOS_SDK} \
+	-c ${PWD}/iOSApp/iOSApp/main.m \
+	-o ${TMP_OUT}/iOSApp/main.o \
 	-index-store-path ${TMP_INDEX_STORE}

--- a/Sources/BKBuildService/PrettyPrinter.swift
+++ b/Sources/BKBuildService/PrettyPrinter.swift
@@ -86,6 +86,7 @@ extension Array where Element == UInt8 {
         guard let bytesAsString = self.utf8String ?? self.asciiString else {
             fatalError("Failed to encode bytes")
         }
+
         return bytesAsString
     }
 

--- a/Sources/BKBuildService/Service.swift
+++ b/Sources/BKBuildService/Service.swift
@@ -58,7 +58,6 @@ public class BKBuildService {
     private var bufferNext = Data()
     private var readLen: Int32 = 0
     private var msgId: UInt64 = 0
-    private var workingDir: String?
 
     // This is highly experimental
     private var indexingEnabled: Bool
@@ -66,17 +65,16 @@ public class BKBuildService {
     // TODO: Move record mode out
     private var chunkId = 0
 
-    public init(indexingEnabled: Bool=false, workingDir: String? = nil) {
+    public init(indexingEnabled: Bool=false) {
         self.indexingEnabled = indexingEnabled
         self.shouldDump = CommandLine.arguments.contains("--dump")
         self.shouldDumpHumanReadable = CommandLine.arguments.contains("--dump_h")
-        self.workingDir = workingDir
     }
 
     // Once a buffer is ready to write to stdout and respond to Xcode invoke this
     func handleRequest(messageHandler: @escaping XCBMessageHandler, context: Any?) {
         let result = Unpacker.unpackAll(self.buffer)
-        let input = XCBInputStream(result: result, data: self.buffer, workingDir: self.workingDir)
+        let input = XCBInputStream(result: result, data: self.buffer)
         let decoder = XCBDecoder(input: input)
         let msg = decoder.decodeMessage()
 

--- a/Sources/XCBProtocol/Packer.swift
+++ b/Sources/XCBProtocol/Packer.swift
@@ -117,14 +117,12 @@ public struct XCBInputStream  {
     public let data: Data
     public var stream: IndexingIterator<[MessagePackValue]>
     public let first: MessagePackValue
-    public let workingDir: String?
 
     // This thing reads in a result - maybe it will not do this.
-    public init (result: [MessagePackValue], data: Data, workingDir: String? = nil) {
+    public init (result: [MessagePackValue], data: Data) {
         self.stream = result.makeIterator()
         self.data = data
         self.first = result.first ?? .uint(0)
-        self.workingDir = workingDir
     }
 
     mutating func next() -> MessagePackValue? {

--- a/Sources/XCBProtocol/Packer.swift
+++ b/Sources/XCBProtocol/Packer.swift
@@ -117,12 +117,14 @@ public struct XCBInputStream  {
     public let data: Data
     public var stream: IndexingIterator<[MessagePackValue]>
     public let first: MessagePackValue
+    public let workingDir: String?
 
     // This thing reads in a result - maybe it will not do this.
-    public init (result: [MessagePackValue], data: Data) {
+    public init (result: [MessagePackValue], data: Data, workingDir: String? = nil) {
         self.stream = result.makeIterator()
         self.data = data
         self.first = result.first ?? .uint(0)
+        self.workingDir = workingDir
     }
 
     mutating func next() -> MessagePackValue? {

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -236,7 +236,7 @@ public struct IndexingInfoRequested: XCBProtocolMessage {
 
         // Remove last word of `$PWD/iOSApp/iOSApp.xcodeproj` to get `workingDir`
         let containerPath = requestJSON["containerPath"] as? String ?? ""
-        self.workingDir = input.workingDir ?? Array(containerPath.components(separatedBy: "/").dropLast()).joined(separator: "/")
+        self.workingDir = Array(containerPath.components(separatedBy: "/").dropLast()).joined(separator: "/")
 
         let jsonRep64Str = requestJSON["jsonRepresentation"] as? String ?? ""
         let jsonRepData = Data.fromBase64(jsonRep64Str) ?? Data()

--- a/Sources/XCBProtocol/Protocol.swift
+++ b/Sources/XCBProtocol/Protocol.swift
@@ -96,16 +96,23 @@ public struct CreateSessionRequest: XCBProtocolMessage {
             self.xcbuildDataPath = ""
         }
 
-        // TODO: This is hacky, just an initial approach for better DX for now. Find a better way.
-        //
-        // `self.xcbuildDataPath` looks something like this (not that `/path/to/DerivedData` can also be a custom path):
+        // `self.xcbuildDataPath` looks something like this (note that `/path/to/DerivedData` can also be a custom path):
         //
         // /path/to/DerivedData/iOSApp-frhmkkebaragakhdzyysbrsvbgtc/Build/Intermediates.noindex/XCBuildData
         //
-        var components = self.xcbuildDataPath.components(separatedBy: "-")
-        self.workspaceHash = components.last!.components(separatedBy: "/").first!
-        components.removeLast()
-        self.workspaceName = components.last!.components(separatedBy: "/").last!
+        let componentsByDash = self.xcbuildDataPath.components(separatedBy: "-")
+        let parsedWorkspaceHash = componentsByDash.last!.components(separatedBy: "/").first ?? ""
+        self.workspaceHash = parsedWorkspaceHash
+
+        // Workspace names can contain `-` characters too
+        let componentsByForwardSlash = self.xcbuildDataPath.components(separatedBy: "/")
+        if let workspaceNameComponent = componentsByForwardSlash.filter { $0.contains(parsedWorkspaceHash) }.first as? String {
+            var workspaceNameComponentsByDash = workspaceNameComponent.components(separatedBy: "-")
+            workspaceNameComponentsByDash.removeLast()
+            self.workspaceName = String(workspaceNameComponentsByDash.joined(separator: "-"))
+        } else {
+            self.workspaceName = ""
+        }
 
         log("Found XCBuildData path: \(self.xcbuildDataPath)")
         log("Parsed workspaceHash: \(self.workspaceHash)")
@@ -229,7 +236,7 @@ public struct IndexingInfoRequested: XCBProtocolMessage {
 
         // Remove last word of `$PWD/iOSApp/iOSApp.xcodeproj` to get `workingDir`
         let containerPath = requestJSON["containerPath"] as? String ?? ""
-        self.workingDir = Array(containerPath.components(separatedBy: "/").dropLast()).joined(separator: "/")
+        self.workingDir = input.workingDir ?? Array(containerPath.components(separatedBy: "/").dropLast()).joined(separator: "/")
 
         let jsonRep64Str = requestJSON["jsonRepresentation"] as? String ?? ""
         let jsonRepData = Data.fromBase64(jsonRep64Str) ?? Data()

--- a/iOSApp/iOSApp.xcodeproj/project.pbxproj
+++ b/iOSApp/iOSApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AF77992028C2AF92009E5F7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C45F55C01FD2199000A6C9F8 /* main.m */; };
 		C56EA31B23107E6F00A9FB8F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C56EA31A23107E6E00A9FB8F /* main.m */; };
 /* End PBXBuildFile section */
 
@@ -85,6 +86,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C45F55C41FD2199000A6C9F8 /* Build configuration list for PBXNativeTarget "iOSApp" */;
 			buildPhases = (
+				AF77991F28C2AF8E009E5F7B /* Sources */,
 			);
 			buildRules = (
 			);
@@ -151,6 +153,14 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		AF77991F28C2AF8E009E5F7B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF77992028C2AF92009E5F7B /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C56EA31423107E6E00A9FB8F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
#### Summary

* Finish buffering logic
* Bring back `make_debug_*` actions that were broken
* Remove some stuff from the clang plist stub, sometimes Xcode will clear cache and setup the data store again and those flags were causing it to fail, will investigate that separately
* Add `TODO`s with examples of what the bazel paths will look like for reference, the Bazel example will be added to `rules_ios` as a follow up
* Add phase to `iOSApp` target to compile `main.m`, this was missing. Now indexing works regarding of the target selected in `iOSApp/iOSApp.xcodeproj`
* `make generate_custom_index_store` now generates object files and index store to support both `CLI` and `iOSApp` targets
* Better `self.workspaceName` parsing
* Added some `do catch` to better log failures during unpacking 

#### Testing

* First make sure Xcode's derived data is configured to point to `/tmp/xcbuild-dd`
* Run `make generate_custom_index_store` to generate index store and object files
* Run `make open_xcode` or `make open_xcode_with_sk_logging`
* Edit any `main.m` file (in `CLI` or `iOSApp` targets) and see indexing working on the UI and also files being read/written under `/tmp/xcbuild-dd/iOSApp-frhmkkebaragakhdzyysbrsvbgtc/Index/DataStore/v5`