### PR TITLE
Pkg install logic for Xcode 13

### DIFF
--- a/utils/InstallerPkg/scripts/postinstall
+++ b/utils/InstallerPkg/scripts/postinstall
@@ -4,7 +4,7 @@ set -e
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
-SUPPORTED_VERSIONS=(11 12)
+SUPPORTED_VERSIONS=(11 12 13)
 
 function install_for_xcode() {
     echo "Installing for Xcode $1"

--- a/utils/uninstall.sh
+++ b/utils/uninstall.sh
@@ -3,7 +3,7 @@ set -e
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
-SUPPORTED_VERSIONS=(11 12)
+SUPPORTED_VERSIONS=(11 12 13)
 
 function uninstall_for_xcode() {
   echo "Checking install for Xcode $1"


### PR DESCRIPTION
This is to make it easier to iterate on changes coming soon to integrate this with `rules_ios`:

* Add Xcode 13 to list of supported versions
~* Make `XCBBuildServiceProxy` "installable"~
~* Install `XCBBuildServiceProxy` by default instead of `BazelBuildService` since I'll iterate a lot on it moving forward. Open to create a separate target if keeping `BazelBuildService` around is desired.~