### PR TITLE
Add indexingEnabled check

### DIFF
--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -54,6 +54,10 @@ private let outputFileForSource: [String: [String: String]] = [
     // "Test-XCBuildKit/Users/thiago/Development/rules_ios/tests/ios/app/App/Foo.m": "bazel-out/ios-x86_64-min10.0-applebin_ios-ios_x86_64-dbg-ST-0f1b0425081f/bin/tests/ios/app/_objs/App_objc/arc/Foo.o",
 ]
 
+// Experimental, enables indexing buffering logic
+// Make sure indexing is enabled first, i.e., run `make enable_indexing`
+private let indexingEnabled: Bool = true
+// Used when debugging msgs are enabled, see `XCBBuildServiceProcess.MessageDebuggingEnabled()`
 private var gChunkNumber = 0
 // FIXME: get this from the other paths
 private var gXcode = ""
@@ -128,7 +132,7 @@ enum BasicMessageHandler {
                 workspaceHash = createSessionRequest.workspaceHash
                 workspaceName = createSessionRequest.workspaceName
                 xcbbuildService.startIfNecessary(xcode: gXcode)
-            } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && msg is IndexingInfoRequested {
+            } else if !XCBBuildServiceProcess.MessageDebuggingEnabled() && indexingEnabled && msg is IndexingInfoRequested {
                 // Example of a custom indexing service
                 let reqMsg = msg as! IndexingInfoRequested
                 workingDir = reqMsg.workingDir
@@ -181,7 +185,7 @@ enum BasicMessageHandler {
 }
 
 let xcbbuildService = XCBBuildServiceProcess()
-let bkservice = BKBuildService(indexingEnabled: true)
+let bkservice = BKBuildService(indexingEnabled: indexingEnabled)
 
 let context = BasicMessageContext(
     xcbbuildService: xcbbuildService,

--- a/Sources/BKBuildService/Service.swift
+++ b/Sources/BKBuildService/Service.swift
@@ -60,7 +60,7 @@ public class BKBuildService {
     private var msgId: UInt64 = 0
 
     // This is highly experimental
-    private var indexingEnabled: Bool
+    private var indexingEnabled: Bool = false
 
     // TODO: Move record mode out
     private var chunkId = 0
@@ -87,7 +87,7 @@ public class BKBuildService {
         ogData.append(self.bufferContentSize)
         ogData.append(self.buffer)
 
-        if msg is IndexingInfoRequested {
+        if msg is IndexingInfoRequested && self.indexingEnabled {
             // Indexing msgs require a PING on the msgId before passing the payload
             // doing this here so proxy writers don't have to worry about this impl detail
             write([


### PR DESCRIPTION
Prep work to (conditionally) adopt indexing in `BazelBuildService`. In theory this flag should've been fully removed as part of https://github.com/jerrymarino/xcbuildkit/pull/43 but we still want services to be able to conditionally adopt this behaviour while this is still WIP. 

The buffering logic is complete but the indexing "end-to-end" story is still WIP (specially in Bazel) so probably better to continue to short circuit unless explicitly requested. 

After this we will keep `indexingEnabled = false` by default in `BazelBuildService` but add the indexing logic to it to be tested during development only when one flips that to `true`. At the same time consumers of `BazelBuildService` today won't be affected since it will be `false` by default. This `BazelBuildService` specific work is coming up in a follow up, this PR contains is just some setup for that and I figured it would make sense to get reviews separately.