### PR TITLE
Fix readLen when initializing buffer

### DIFF
--- a/Sources/BKBuildService/Service.swift
+++ b/Sources/BKBuildService/Service.swift
@@ -173,7 +173,7 @@ public class BKBuildService {
         //
         // Returns `false` meaning that the buffer is still not ready to be processed
         self.buffer.append(bufferData)
-        self.readLen = min(max(size - Int32(bufferData.count), 0), Int32(bufferData.count))
+        self.readLen = size - Int32(bufferData.count)
 
         return false
     }


### PR DESCRIPTION
**TL;DR**: This calculation is too complicated, we just need to remove the size of the data that was just accumulated and the remaining is the new `readLen`.

When testing this in an Xcode project with more data and bigger payloads realized that this calculation is more complicated than it needs to be. There's a check a few lines above the one I'm fixing here that already guarantees that `size` is greater than `Int32(bufferData.count)` so this `min`, `man` magic is not necessary here.

Hit a bug where an incorrect remaining `readLen` was being calculated due to the `min` in this calculation. Only hit this bug in a single payload that was bigger than the average I've seen so far (size was something like `9886`).