### PR TITLE
Continue if remainder is empty

### DIFF
--- a/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift
+++ b/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift
@@ -74,7 +74,7 @@ func unpackArray(_ data: Subdata, count: Int, compatibility: Bool) throws -> (va
     var newValue: MessagePackValue
 
     for _ in 0 ..< count {
-        guard !remainder.isEmpty else { continue }
+        guard !remainder.isEmpty else { break }
 
         (newValue, remainder) = try unpack(remainder, compatibility: compatibility)
         values.append(newValue)

--- a/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift
+++ b/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift
@@ -74,6 +74,8 @@ func unpackArray(_ data: Subdata, count: Int, compatibility: Bool) throws -> (va
     var newValue: MessagePackValue
 
     for _ in 0 ..< count {
+        guard !remainder.isEmpty else { continue }
+
         (newValue, remainder) = try unpack(remainder, compatibility: compatibility)
         values.append(newValue)
     }


### PR DESCRIPTION
While testing this noticed that when the build service is *disabled* there's an edge case in proxying messages. The gist is that before completing the buffering logic the unpacker was parsing partial msgs in some cases when the payload was too big. 

Now we're always accumulating the complete payload in a `buffer` and then doing one of (1) handle the message in a build service's impl (2) proxying the msg passing the complete `buffer` containing all the payload.

The issue here is that in one project I'm using to test, if the build service is installed on the machine but disabled (2) is failing here https://github.com/jerrymarino/xcbuildkit/blob/master/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift#L115-L117 because `data` is empty. So the msg fails to be proxied.

Noticed that the problematic call site is here: https://github.com/jerrymarino/xcbuildkit/blob/master/third_party/xcbuildkit-MessagePack/Sources/MessagePack/Unpack.swift#L77

I believe this bug was hidden because of how unpacking worked prior to the new buffering logic, i.e., not always parsing the complete payload for big msgs vs now where we always have the complete payload ready to be handled or proxied.