### PR TITLE
Remove unnecessary unpacking

### DIFF
--- a/Examples/BSBuildService/main.swift
+++ b/Examples/BSBuildService/main.swift
@@ -11,11 +11,11 @@ struct BasicMessageContext {
 /// XCBBuildService. All messages from Xcode are handled internally and XCBuild
 /// is not used
 enum BasicMessageHandler {
-    static func respond(input: XCBInputStream, data _: Data, context: Any?) {
+    static func respond(input: XCBInputStream, data _: Data, msgId: UInt64, context: Any?) {
         let basicCtx = context as! BasicMessageContext
         let bkservice = basicCtx.bkservice
         let decoder = XCBDecoder(input: input)
-        let encoder = XCBEncoder(input: input)
+        let encoder = XCBEncoder(input: input, msgId: msgId)
         if let msg = decoder.decodeMessage() {
             if msg is CreateSessionRequest {
                 bkservice.write(try! CreateSessionResponse().encode(encoder))

--- a/Examples/BazelBuildService/BEPService.swift
+++ b/Examples/BazelBuildService/BEPService.swift
@@ -8,7 +8,7 @@ import XCBProtocol
 // keep all logic here now for simplicity.
 class BEPService {
   // Read info from BEP and optionally handle events
-  func startStream(msg: WorkspaceInfoKeyable, bepPath: String, startBuildInput: XCBInputStream, ctx: BasicMessageContext) throws {
+  func startStream(msg: WorkspaceInfoKeyable, bepPath: String, startBuildInput: XCBInputStream, msgId: UInt64, ctx: BasicMessageContext) throws {
         guard let info = ctx.indexingService.infos[msg.workspaceKey] else { return }
 
         log("[INFO] Will start BEP stream at path \(bepPath) with input" + String(describing: startBuildInput))
@@ -23,7 +23,7 @@ class BEPService {
 
             if info.config.progressBarEnabled {
                 if let updatedView = ProgressView(event: event, last: progressView) {
-                    let encoder = XCBEncoder(input: startBuildInput)
+                    let encoder = XCBEncoder(input: startBuildInput, msgId: msgId)
                     let response = BuildProgressUpdatedResponse(progress:
                         updatedView.progressPercent, message: updatedView.message)
                     if let responseData = try? response.encode(encoder) {

--- a/Examples/BazelBuildService/BazelBuildServiceConfig.swift
+++ b/Examples/BazelBuildService/BazelBuildServiceConfig.swift
@@ -9,7 +9,7 @@
 //
 // TODO: Codable?
 // TODO: Not load from disk all the time but still detect changes in the file and refresh in-memory values?
-struct BazelBuildServiceConfig {
+struct BazelBuildServiceConfig: CustomDebugStringConvertible {
   private enum ConfigKeys: String {
     case indexingEnabled = "BUILD_SERVICE_INDEXING_ENABLED"
     case indexStorePath = "BUILD_SERVICE_INDEX_STORE_PATH"
@@ -32,6 +32,10 @@ struct BazelBuildServiceConfig {
 
   init(configPath: String) {
     self.configPath = configPath
+  }
+
+  var debugDescription: String {
+    return "\(self.loadConfigFile ?? [:])"
   }
 
   private var loadConfigFile: [String: Any]? {

--- a/Examples/HybridBuildService/main.swift
+++ b/Examples/HybridBuildService/main.swift
@@ -40,12 +40,12 @@ struct BasicMessageContext {
 // This is an example build service that implements the build portion
 // all other messages and operations are handled by XCBuild
 enum BasicMessageHandler {
-    static func respond(input: XCBInputStream, data: Data, context: Any?) {
+    static func respond(input: XCBInputStream, data: Data, msgId: UInt64, context: Any?) {
         let basicCtx = context as! BasicMessageContext
         let xcbbuildService = basicCtx.xcbbuildService
         let bkservice = basicCtx.bkservice
         let decoder = XCBDecoder(input: input)
-        let encoder = XCBEncoder(input: input)
+        let encoder = XCBEncoder(input: input, msgId: msgId)
         if let msg = decoder.decodeMessage() {
             if let createSessionRequest = msg as? CreateSessionRequest {
                 xcbbuildService.startIfNecessary(xcode: createSessionRequest.xcode)

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -122,12 +122,12 @@ enum BasicMessageHandler {
     /// Proxying response handler
     /// Every message is written to the XCBBuildService
     /// This simply injects Progress messages from the BEP
-    static func respond(input: XCBInputStream, data: Data, context: Any?) {
+    static func respond(input: XCBInputStream, data: Data, msgId: UInt64, context: Any?) {
         let basicCtx = context as! BasicMessageContext
         let xcbbuildService = basicCtx.xcbbuildService
         let bkservice = basicCtx.bkservice
         let decoder = XCBDecoder(input: input)
-        let encoder = XCBEncoder(input: input)
+        let encoder = XCBEncoder(input: input, msgId: msgId)
         if let msg = decoder.decodeMessage() {
             if let createSessionRequest = msg as? CreateSessionRequest {
                 gXcode = createSessionRequest.xcode

--- a/Sources/XCBProtocol/Coder.swift
+++ b/Sources/XCBProtocol/Coder.swift
@@ -2,24 +2,21 @@ import Foundation // For log()
 
 public class XCBEncoder {
     let input: XCBInputStream
+    let msgId: UInt64
 
-    public init(input: XCBInputStream) {
+    public init(input: XCBInputStream, msgId: UInt64 = 0) {
         self.input = input
+        self.msgId = msgId
     }
 
     /// This is state of protocol messages, and perhaps it would be encapsulated in a
     /// better way. Xcode uses this internally
     func getMsgId() throws -> UInt64 {
-        var v = self.input
-        guard let next = v.next(),
-            case let .uint(id) = next else {
-            // This happens when there is unexpected input. There is an
-            // unimplemented where this does happen, triggered by
-            // BazelBuildService.
-            log("missing id for msg: " + String(describing: self.input))
+        guard self.msgId > 0 else {
+            log("[ERROR] Missing id for msg: " + String(describing: self.input))
             throw XCBProtocolError.unexpectedInput(for: self.input)
         }
-        return id + 1
+        return self.msgId + 1
     }
 }
 

--- a/Sources/XCBProtocol/Packer.swift
+++ b/Sources/XCBProtocol/Packer.swift
@@ -114,7 +114,6 @@ public protocol XCBValue {
 public typealias XCBRawValue = MessagePackValue
 
 public struct XCBInputStream  {
-    public let data: Data
     public var stream: IndexingIterator<[MessagePackValue]>
     public let first: MessagePackValue
     // Used for debugging only, assumes the first .string found is the identifier for this msg
@@ -132,9 +131,8 @@ public struct XCBInputStream  {
     }
 
     // This thing reads in a result - maybe it will not do this.
-    public init (result: [MessagePackValue], data: Data) {
+    public init (result: [MessagePackValue]) {
         self.stream = result.makeIterator()
-        self.data = data
         self.first = result.first ?? .uint(0)
     }
 


### PR DESCRIPTION
* Pass `msgId` from `BKBuildService` instead of re-unpacking in other places
* Remove unnecessary unpacking to special case `CreateSessionRequest`
* `XCBInputStream` => `public let data: Data` was not being used at all and call sites were unnecessarily trying to unpack it generating false negative `Unpacker has failed` errors
* Make `BazelBuildServiceConfig` debug printable to easily inspect the config file
* Add more logs