### PR TITLE
[HOLD] Swift indexing pt. 1

### DIFF
--- a/Examples/BazelBuildService/BazelBuildServiceStub.swift
+++ b/Examples/BazelBuildService/BazelBuildServiceStub.swift
@@ -45,7 +45,7 @@ let clangXMLT: String = """
                 <key>LanguageDialect</key>
                 <string>objective-c</string>
                 <key>clangASTBuiltProductsDir</key>
-                <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORSPACE_HASH__/Index/Build/Products/Debug-iphonesimulator</string>
+                <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
                 <key>clangASTCommandArguments</key>
                 <array>
                         <string>-x</string>
@@ -154,8 +154,75 @@ let clangXMLT: String = """
 </plist>
 """
 
+let swiftXMLT: String = """
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<dict>
+			<key>LanguageDialect</key>
+			<string>swift</string>
+			<key>outputFilePath</key>
+			<string>__OUTPUT_FILE_PATH__</string>
+			<key>sourceFilePath</key>
+			<string>__SOURCE_FILE__</string>
+			<key>swiftASTBuiltProductsDir</key>
+			<string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
+			<key>swiftASTCommandArguments</key>
+			<array>
+                                <string>-module-name</string>
+				<string>__MODULE_NAME__</string>
+				<string>-Onone</string>
+				<string>-enforce-exclusivity=checked</string>
+				<string>-sdk</string>
+				<string>__SDK_PATH__</string>
+				<string>-target</string>
+				<string>x86_64-apple-ios11.0-simulator</string>
+				<string>-g</string>
+				<string>-module-cache-path</string>
+				<string>__DERIVED_DATA_PATH__/ModuleCache.noindex</string>
+				<string>-Xfrontend</string>
+				<string>-serialize-debugging-options</string>
+				<string>-enable-testing</string>
+				<string>-swift-version</string>
+				<string>5</string>
+				<string>-parse-as-library</string>
+				<string>-Xfrontend</string>
+				<string>-experimental-allow-module-with-compiler-errors</string>
+				<string>-Xcc</string>
+				<string>-Xclang</string>
+				<string>-Xcc</string>
+				<string>-fallow-pcm-with-compiler-errors</string>
+				<string>-Xcc</string>
+				<string>-Xclang</string>
+				<string>-Xcc</string>
+				<string>-fmodule-format=raw</string>
+				<string>-Xcc</string>
+				<string>-Xclang</string>
+				<string>-Xcc</string>
+				<string>-detailed-preprocessing-record</string>
+				<string>-num-threads</string>
+				<string>10</string>
+                                <string>-DXCBTEST</string>
+				<string>-Xcc</string>
+				<string>-DDEBUG=1</string>
+				<string>-working-directory</string>
+				<string>__WORKING_DIR__</string>
+				<string>__SOURCE_FILE__</string>
+			</array>
+			<key>swiftASTModuleName</key>
+			<string>__MODULE_NAME__</string>
+			<key>toolchains</key>
+			<array>
+				<string>com.apple.dt.toolchain.XcodeDefault</string>
+			</array>
+		</dict>
+	</array>
+</plist>
+"""
+
 public enum BazelBuildServiceStub {
-        public static func getASTArgs(targetID: String,
+        public static func getASTArgs(isSwift: Bool,
+                                      targetID: String,
                                       sourceFilePath: String,
                                       outputFilePath: String,
                                       derivedDataPath: String,
@@ -163,18 +230,25 @@ public enum BazelBuildServiceStub {
                                       workspaceName: String,
                                       sdkPath: String,
                                       sdkName: String,
-                                      workingDir: String) -> Data {
-                let clangXML = clangXMLT.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
+                                      workingDir: String,
+                                      configuration: String,
+                                      platform: String) -> Data {
+                var stub = isSwift ? swiftXMLT : clangXMLT
+                stub = stub.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
                 .replacingOccurrences(of:"__OUTPUT_FILE_PATH__", with: outputFilePath)
                 .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/\(workspaceName)-\(workspaceHash)/Index/DataStore")
                 .replacingOccurrences(of:"__WORKSPACE_NAME__", with: workspaceName)
                 .replacingOccurrences(of:"__DERIVED_DATA_PATH__", with: derivedDataPath)
-                .replacingOccurrences(of:"__WORSPACE_HASH__", with: workspaceHash)
+                .replacingOccurrences(of:"__WORKSPACE_HASH__", with: workspaceHash)
                 .replacingOccurrences(of:"__SDK_PATH__", with: sdkPath)
+                .replacingOccurrences(of:"__BAZEL_XCODE_SDKROOT__", with: sdkPath)
                 .replacingOccurrences(of:"__SDK_NAME__", with: sdkName)
                 .replacingOccurrences(of:"__WORKING_DIR__", with: workingDir)
+                .replacingOccurrences(of:"__CONFIGURATION__", with: configuration)
+                .replacingOccurrences(of:"__PLATFORM__", with: platform)
+                .replacingOccurrences(of:"__MODULE_NAME__", with: "Chartography_DemoApp")
 
-                return BPlistConverter(xml: clangXML)?.convertToBinary() ?? Data()
+                return BPlistConverter(xml: stub)?.convertToBinary() ?? Data()
         }
 
         // Required if `outputPathOnly` is `true` in the indexing request

--- a/Examples/BazelBuildService/WorkspaceInfo.swift
+++ b/Examples/BazelBuildService/WorkspaceInfo.swift
@@ -18,6 +18,7 @@ class WorkspaceInfo {
   var derivedDataPath: String = ""
   var indexDataStoreFolderPath: String = ""
   var bepStream: BEPStream?
+  var targetConfiguration: String = "Debug"
 
   // Dictionary that holds mapping from source file to respective `.o` file under `bazel-out`. Used to respond to indexing requests.
   //

--- a/Sources/BKBuildService/XCBBuildServiceProcess.swift
+++ b/Sources/BKBuildService/XCBBuildServiceProcess.swift
@@ -95,7 +95,6 @@ public class XCBBuildServiceProcess {
         }
     }
 
-
     public func start(path: String) {
         log("Starting build service:" + path)
         self.stdout.fileHandleForReading.readabilityHandler = {

--- a/iOSApp/iOSApp.xcodeproj/project.pbxproj
+++ b/iOSApp/iOSApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AF77992028C2AF92009E5F7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C45F55C01FD2199000A6C9F8 /* main.m */; };
+		AFC5E93629252F2100B1F21C /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC5E93529252F2100B1F21C /* Test.swift */; };
 		C56EA31B23107E6F00A9FB8F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C56EA31A23107E6E00A9FB8F /* main.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AFC5E93429252F2100B1F21C /* iOSApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOSApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		AFC5E93529252F2100B1F21C /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 		C45F55AE1FD2199000A6C9F8 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C45F55BF1FD2199000A6C9F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C45F55C01FD2199000A6C9F8 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -67,6 +70,8 @@
 			children = (
 				C45F55BF1FD2199000A6C9F8 /* Info.plist */,
 				C45F55C01FD2199000A6C9F8 /* main.m */,
+				AFC5E93529252F2100B1F21C /* Test.swift */,
+				AFC5E93429252F2100B1F21C /* iOSApp-Bridging-Header.h */,
 			);
 			path = iOSApp;
 			sourceTree = "<group>";
@@ -125,6 +130,7 @@
 				TargetAttributes = {
 					C45F55AD1FD2199000A6C9F8 = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 1330;
 						ProvisioningStyle = Manual;
 					};
 					C56EA31723107E6E00A9FB8F = {
@@ -158,6 +164,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF77992028C2AF92009E5F7B /* main.m in Sources */,
+				AFC5E93629252F2100B1F21C /* Test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +213,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -225,6 +233,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_MODULE_NAME = "";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -263,6 +272,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -275,6 +285,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_MODULE_NAME = "";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -284,11 +295,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COLOR_DIAGNOSTICS = NO;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = iOSApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -297,8 +310,12 @@
 					"-fno-color-diagnostics",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jerry.iOSApp;
+				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "iOSApp/iOSApp-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = "";
@@ -309,11 +326,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COLOR_DIAGNOSTICS = NO;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = iOSApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -322,8 +341,11 @@
 					"-fno-color-diagnostics",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jerry.iOSApp;
+				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "iOSApp/iOSApp-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = "";

--- a/iOSApp/iOSApp/Test.swift
+++ b/iOSApp/iOSApp/Test.swift
@@ -1,0 +1,14 @@
+//
+//  Test.swift
+//  iOSApp
+//
+//  Created by Thiago on 2022-11-16.
+//  Copyright © 2022 jerry. All rights reserved.
+//
+
+import Foundation
+
+class FooSwift: NSObject {
+    @objc func foo() {
+    }
+}

--- a/iOSApp/iOSApp/iOSApp-Bridging-Header.h
+++ b/iOSApp/iOSApp/iOSApp-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/iOSApp/iOSApp/main.m
+++ b/iOSApp/iOSApp/main.m
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
-//
+#import "iOSApp-Swift.h"
+
 int main(int argc, char * argv[]) {
+    [[[FooSwift alloc] init] foo];
     exit(0);
 }


### PR DESCRIPTION
This covers pt.1 for Swift indexing: Finding `.o` files and proxying the correct payload. Next (pt. 2) will be to align `clang/swiftc` invocations with Bazel.

* Better defaults in `clang` stubs
* Add `swiftc` stub
* Minor optimization to only look for `.o` files in the in-memory cache when the correct filename suffix is present
* Addresses a couple of Swift `TODO`s
* Read `CONFIGURATION` (e.g. `Debug`/`Release`) from request payload and stop hard coding it
* Put back `XCBBuildServiceProxy` as the default "debug mode" service and fix some issues introduced when changing `BazelBuildService` last time
* Add Swift source to `iOSApp`

To test this follow the steps below:
1. Generate pre-built index store (now including Swift outputs)
```sh
make generate_custom_index_store
```
2. Open Xcode with SK logs:
```sh
make open_xcode_with_sk_logging
```
3. Note that you can build with no errors and navigate from `iOSApp => main.m` to `iOSApp/iOSApp/Test.swift` via "jump to definition".
