### PR TITLE
Align swiftc invocations between Bazel and Xcode during indexing

### DIFF
--- a/Examples/BazelBuildService/IndexingService.swift
+++ b/Examples/BazelBuildService/IndexingService.swift
@@ -66,8 +66,8 @@ class IndexingService {
         guard info.config.indexingEnabled else {
             return nil
         }
-        // TODO: handle Swift
-        guard msg.filePath.count > 0 && msg.filePath != "<garbage>" && !msg.filePath.hasSuffix(".swift") else {
+        // Skip unsupported/invalid `filePath` values
+        guard msg.filePath.count > 0 && msg.filePath != "<garbage>" else {
             log("[WARNING] Unsupported filePath for indexing: \(msg.filePath)")
             return nil
         }
@@ -98,6 +98,7 @@ class IndexingService {
             info.outputFileForSource[jsonFilename] = [:]
         }
         info.outputFileForSource[jsonFilename] = jsonValues
+        log("[INFO] Loaded \(jsonFilename) into in-memory cache")
 
         // Update .json files cached under xcbuildkitDataDir for
         // fast load next time we launch Xcode

--- a/Examples/BazelBuildService/main.swift
+++ b/Examples/BazelBuildService/main.swift
@@ -85,6 +85,7 @@ enum BasicMessageHandler {
                 // Compose the indexing response payload and emit the response message
                 // Note that information is combined from different places (workspace info, incoming indexing request, indexing service helper methods)
                 let compilerInvocationData = BazelBuildServiceStub.getASTArgs(
+                    isSwift: indexingInfoRequest.filePath.hasSuffix(".swift"),
                     targetID: indexingInfoRequest.targetID,
                     xcode: workspaceInfo.xcode,
                     sourceFilePath: indexingInfoRequest.filePath,


### PR DESCRIPTION
* Add Swift stub with minimal number of properties necessary to correctly send indexing msgs to Xcode
* Where the stub receive the resolved values added logic to collect `-module-name` from compiler flags and set in the plist
* Resolve Swift indexing related `TODO:`s