### PR TITLE
Add swift test case for fix-its and indexing

### DIFF
--- a/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
+++ b/Examples/XCBBuildServiceProxy/XCBBuildServiceProxyStub.swift
@@ -156,8 +156,47 @@ let clangXMLT: String = """
 </plist>
 """
 
+let swiftXMLT: String = """
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<dict>
+                        <key>LanguageDialect</key>
+                        <string>swift</string>
+                        <key>outputFilePath</key>
+                        <string>__OUTPUT_FILE_PATH__</string>
+                        <key>sourceFilePath</key>
+                        <string>__SOURCE_FILE__</string>
+                        <key>swiftASTBuiltProductsDir</key>
+                        <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
+                        <key>swiftASTCommandArguments</key>
+                        <array>
+                                <string>-sdk</string>
+                                <string>__SDK_PATH__</string>
+                                <string>-target</string>
+                                <string>x86_64-apple-ios11.0-simulator</string>
+                                <string>-index-store-path</string>
+                                <string>__INDEX_STORE_PATH__</string>
+                                <string>-F</string>
+                                <string>/tmp/xcbuild-out</string>
+                                <string>-o</string>
+                                <string>__OUTPUT_FILE_PATH__</string>
+                                <string>-working-directory</string>
+                                <string>__WORKING_DIR__</string>
+                                <string>__SOURCE_FILE__</string>
+                        </array>
+                        <key>toolchains</key>
+                        <array>
+                                <string>com.apple.dt.toolchain.XcodeDefault</string>
+                        </array>
+		</dict>
+	</array>
+</plist>
+"""
+
 public enum XCBBuildServiceProxyStub {
-        public static func getASTArgs(targetID: String,
+        public static func getASTArgs(isSwift: Bool,
+                                      targetID: String,
                                       sourceFilePath: String,
                                       outputFilePath: String,
                                       derivedDataPath: String,
@@ -168,7 +207,7 @@ public enum XCBBuildServiceProxyStub {
                                       workingDir: String,
                                       configuration: String,
                                       platform: String) -> Data {
-                var stub = clangXMLT
+                var stub = isSwift ? swiftXMLT : clangXMLT
                 stub = stub.replacingOccurrences(of:"__SOURCE_FILE__", with: sourceFilePath)
                 .replacingOccurrences(of:"__OUTPUT_FILE_PATH__", with: outputFilePath)
                 .replacingOccurrences(of:"__INDEX_STORE_PATH__", with: "\(derivedDataPath)/\(workspaceName)-\(workspaceHash)/Index/DataStore")

--- a/Examples/XCBBuildServiceProxy/main.swift
+++ b/Examples/XCBBuildServiceProxy/main.swift
@@ -45,7 +45,9 @@ private let outputFileForSource: [String: [String: String]] = [
     "iOSApp-frhmkkebaragakhdzyysbrsvbgtc": [
         "/CLI/main.m": "/tmp/xcbuild-out/CLI/main.o",
         "/iOSApp/main.m": "/tmp/xcbuild-out/iOSApp/main.o",
+        "/iOSApp/Test.swift": "/tmp/xcbuild-out/iOSApp/Test.swift.o",
         "/FW1/FW1.m": "/tmp/xcbuild-out/FW1/FW1.o",
+        "/FW1/FW1.swift": "/tmp/xcbuild-out/FW1/FW1.swift.o",
     ],
 
     // TODO: Should come from an aspect in Bazel
@@ -159,6 +161,7 @@ enum BasicMessageHandler {
                 log("[INFO] Found output file \(outputFilePath) for source \(reqMsg.filePath)")
 
                 let compilerInvocationData = XCBBuildServiceProxyStub.getASTArgs(
+                    isSwift: reqMsg.filePath.hasSuffix(".swift"),
                     targetID: reqMsg.targetID,
                     sourceFilePath: reqMsg.filePath,
                     outputFilePath: outputFilePath,

--- a/iOSApp/FW1/FW1.m
+++ b/iOSApp/FW1/FW1.m
@@ -20,7 +20,7 @@
 
      "Replace '%s' with '%d'"
 
-     and a "FIX" action on the right side
+     and a "Fix" action on the right side
     */
     NSLog(@"%s", 1);
 }

--- a/iOSApp/FW1/FW1.swift
+++ b/iOSApp/FW1/FW1.swift
@@ -1,0 +1,14 @@
+//
+//  FW1Test.swift
+//  FW1
+//
+//  Created by Thiago on 2023-01-12.
+//  Copyright © 2023 jerry. All rights reserved.
+//
+
+import Foundation
+
+public protocol FW1Protocol {
+    func foo1()
+    func foo2()
+}

--- a/iOSApp/iOSApp.xcodeproj/project.pbxproj
+++ b/iOSApp/iOSApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		AF340792296F15DD0094E739 /* FW1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AF34078B296F15DD0094E739 /* FW1.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AF340799296F19740094E739 /* FW1.m in Sources */ = {isa = PBXBuildFile; fileRef = AF340798296F19740094E739 /* FW1.m */; };
 		AF77992028C2AF92009E5F7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C45F55C01FD2199000A6C9F8 /* main.m */; };
+		AF7C835329708ACC00FA2865 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C835229708ACC00FA2865 /* Test.swift */; };
+		AF7C83552970937B00FA2865 /* FW1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7C83542970937B00FA2865 /* FW1.swift */; };
 		C56EA31B23107E6F00A9FB8F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C56EA31A23107E6E00A9FB8F /* main.m */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +54,9 @@
 		AF34078B296F15DD0094E739 /* FW1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FW1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF34078D296F15DD0094E739 /* FW1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FW1.h; sourceTree = "<group>"; };
 		AF340798296F19740094E739 /* FW1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FW1.m; sourceTree = "<group>"; };
+		AF7C835129708ACC00FA2865 /* iOSApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOSApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		AF7C835229708ACC00FA2865 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
+		AF7C83542970937B00FA2865 /* FW1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FW1.swift; sourceTree = "<group>"; };
 		C45F55AE1FD2199000A6C9F8 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C45F55BF1FD2199000A6C9F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C45F55C01FD2199000A6C9F8 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -91,6 +96,7 @@
 			children = (
 				AF34078D296F15DD0094E739 /* FW1.h */,
 				AF340798296F19740094E739 /* FW1.m */,
+				AF7C83542970937B00FA2865 /* FW1.swift */,
 			);
 			path = FW1;
 			sourceTree = "<group>";
@@ -121,6 +127,8 @@
 			children = (
 				C45F55BF1FD2199000A6C9F8 /* Info.plist */,
 				C45F55C01FD2199000A6C9F8 /* main.m */,
+				AF7C835229708ACC00FA2865 /* Test.swift */,
+				AF7C835129708ACC00FA2865 /* iOSApp-Bridging-Header.h */,
 			);
 			path = iOSApp;
 			sourceTree = "<group>";
@@ -211,10 +219,12 @@
 				TargetAttributes = {
 					AF34078A296F15DD0094E739 = {
 						CreatedOnToolsVersion = 13.3.1;
+						LastSwiftMigration = 1330;
 						ProvisioningStyle = Automatic;
 					};
 					C45F55AD1FD2199000A6C9F8 = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 1330;
 						ProvisioningStyle = Manual;
 					};
 					C56EA31723107E6E00A9FB8F = {
@@ -258,6 +268,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF7C83552970937B00FA2865 /* FW1.swift in Sources */,
 				AF340799296F19740094E739 /* FW1.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -267,6 +278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF77992028C2AF92009E5F7B /* main.m in Sources */,
+				AF7C835329708ACC00FA2865 /* Test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,6 +305,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -306,7 +319,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/FW1";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 jerry. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -315,6 +328,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -325,6 +340,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -338,7 +354,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/FW1";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 jerry. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -346,6 +362,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -463,7 +480,9 @@
 		C45F55C51FD2199000A6C9F8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
@@ -480,6 +499,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jerry.iOSApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "iOSApp/iOSApp-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = "";
@@ -489,7 +511,9 @@
 		C45F55C61FD2199000A6C9F8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
@@ -506,6 +530,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jerry.iOSApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "iOSApp/iOSApp-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = "";

--- a/iOSApp/iOSApp/Test.swift
+++ b/iOSApp/iOSApp/Test.swift
@@ -1,0 +1,28 @@
+//
+//  Test1.swift
+//  iOSApp
+//
+//  Created by Thiago on 2023-01-12.
+//  Copyright © 2023 jerry. All rights reserved.
+//
+
+import Foundation
+import FW1
+
+class Test1 {
+}
+
+
+/* Used to test Fix-its, uncomment the class declarion below to test it
+ Expected message:
+
+ "Type 'Test' does not conform to protocol 'FW1Protocol'"
+
+ with a diagnostic note saying:
+
+ "Do you want to add protocol stubs?"
+
+ and a "Fix" action on the right side
+*/
+//class Test2: FW1Protocol {
+//}

--- a/iOSApp/iOSApp/iOSApp-Bridging-Header.h
+++ b/iOSApp/iOSApp/iOSApp-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/iOSApp/iOSApp/main.m
+++ b/iOSApp/iOSApp/main.m
@@ -11,11 +11,12 @@ int main(int argc, char * argv[]) {
 
      "Replace '%s' with '%d'"
 
-     and a "FIX" action on the right side
+     and a "Fix" action on the right side
     */
     NSLog(@"%s", 1);
 
     // Used to make sure FW1 type is available and imported correctly
+    // Can also be used to test "jump to definition"
     [[[FW1 alloc] init] foo];
 
     exit(0);

--- a/templates/FW1/module.modulemap
+++ b/templates/FW1/module.modulemap
@@ -4,3 +4,8 @@ framework module FW1 {
   export *
   module * { export * }
 }
+
+module FW1.Swift {
+    header "FW1-Swift.h"
+    requires objc
+}


### PR DESCRIPTION
So we can use the minimal test case in `xcbuildkit` to test indexing and fix-its for Swift sources.

* Update `iOSApp` project to also contain Swift sources
* Update `XCBBuildServiceProxy` to handle Swift outputs
* Update `XCBBuildServiceProxyStub` to handle Swift too
* `generate_custom_index_store` now also generates Swift outputs