### PR TITLE
Xcode 14.x indexing support pt.1

### DIFF
--- a/Examples/BazelBuildService/BazelBuildServiceStub.swift
+++ b/Examples/BazelBuildService/BazelBuildServiceStub.swift
@@ -45,7 +45,7 @@ let clangXMLT: String = """
                 <key>LanguageDialect</key>
                 <string>objective-c</string>
                 <key>clangASTBuiltProductsDir</key>
-                <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
+                <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index.noindex/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
                 <key>clangASTCommandArguments</key>
                 <array>
                         __CMD_LINE_ARGS__
@@ -55,7 +55,7 @@ let clangXMLT: String = """
                         <string>__SOURCE_FILE__</string>
                 </array>
                 <key>outputFilePath</key>
-                <string>__OUTPUT_FILE_PATH__</string>
+                <string>__WORKING_DIR__/__OUTPUT_FILE_PATH__</string>
                 <key>sourceFilePath</key>
                 <string>__SOURCE_FILE__</string>
                 <key>toolchains</key>
@@ -79,7 +79,7 @@ let swiftXMLT: String = """
                         <key>sourceFilePath</key>
                         <string>__SOURCE_FILE__</string>
                         <key>swiftASTBuiltProductsDir</key>
-                        <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
+                        <string>__DERIVED_DATA_PATH__/__WORKSPACE_NAME__-__WORKSPACE_HASH__/Index.noindex/Build/Products/__CONFIGURATION__-__PLATFORM__</string>
                         <key>swiftASTCommandArguments</key>
                         <array>
                                 __CMD_LINE_ARGS__

--- a/Examples/BazelBuildService/main.swift
+++ b/Examples/BazelBuildService/main.swift
@@ -42,9 +42,6 @@ enum BasicMessageHandler {
 
                 // Initialize build service
                 xcbbuildService.startIfNecessary(xcode: workspaceInfo.xcode)
-
-                // Initialize indexing information
-                indexingService.initializeOutputFileMappingFromCache(msg: createSessionRequest)
             } else if msg is BuildStartRequest {
                 let message = BuildProgressUpdatedResponse()
                 if let responseData = try? message.encode(encoder) {
@@ -70,12 +67,6 @@ enum BasicMessageHandler {
                 workspaceInfo.derivedDataPath = createBuildRequest.derivedDataPath
                 workspaceInfo.indexDataStoreFolderPath = createBuildRequest.indexDataStoreFolderPath
                 workspaceInfo.targetConfiguration = createBuildRequest.configuration
-
-                // Attempt to initialize in-memory mapping if empty
-                // It's possible that indexing data is not ready yet in `CreateSessionRequest` above
-                if workspaceInfo.outputFileForSource.count == 0 {
-                    indexingService.initializeOutputFileMappingFromCache(msg: createBuildRequest)
-                }
 
                 // Setup DataStore for indexing with Bazel
                 indexingService.setupDataStore(msg: createBuildRequest)


### PR DESCRIPTION
Relates to https://github.com/bazel-ios/xchammer/pull/41

Keeping as a draft for now as these changes are not enough yet to fully support it so looking for some help/suggestions. Xcode 14.x still intermittently gets stuck on "Processing files" during indexing for me with this setup. 

This could be because the expected `INDEXING_INFO_RECEIVED` payload needs to be adjusted as I noted that differently than Xcode 13.x (1) `filePath` is not always present in `INDEXING_INFO_REQUESTED` when `outputPathsOnly` is `true` and also (2) when `outputPathOnly` is `true` vanilla Xcode 14.x sends a list of `source file path` + `object file path` instead of just one pair for the current source being requested only. 

Noticed too that the only info available in the `INDEXING_INFO_REQUESTED` payload is the build description ID and the target ID. In theory we can find the `filePath` and the `.o paths` needed to pass forward when `outputPathsOnly` is `true` in this file (which is a JSON):
```sh
path/to/DD/Build/Intermediates.noindex/XCBuildData/<BUILD_DESCRIPTION_ID>-manifest.xcbuild
```
but I'm still considering if this is the best approach.

That said, found some edge cases and made some perf improvements as I was investigating this. To summarize:

* Create a key per source and use that to find the indexing information generated in the [XCHammer's aspect](https://github.com/bazel-ios/xchammer/pull/41) (previously the aspect was creating one file per target forcing `xcbuildkit` to have to loop through all `.json` files and load then into memory to find indexing information, this now loads `.json` files on demand)
* Use `Index.noindex/Build` Xcode 14.x specific path in stubs (IMO we should focus on adding support for Xcode 14.x until this is usable but open to adjust things here to conditionally load things differently on previous versions of Xcode if we feel it's crucial to support that now)

**ps**: a consumer trying to verify/test this needs these two flags in the rc file:
```sh
build --features xcode.collect_indexing_info
build --features=-debug_prefix_map_pwd_is_dot
```
The first is to enable the aspect in XCHammer and the second is so the indexing unit files don't end up with `../path/to/foo.o` paths which will crash Xcode since the working directory can't be empty and Xcode crashes before `XCBBuildService` takes control. Open to suggestions if there's an alternative way instead of disabling `debug_prefix_map_pwd_is_dot` but AFAICT that's one problem `index-import` solves and the intent here is to not rely on `index-import` so we'll have to find another way.